### PR TITLE
fix: add 'parcel' as alternative package name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,18 +14,18 @@
       }
     },
     "@babel/core": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.4.tgz",
-      "integrity": "sha512-Rm0HGw101GY8FTzpWSyRbki/jzq+/PkNQJ+nSulrdY6gFGOsNseCqD6KHRYe2E+EdzuBdr2pxCp6s4Uk6eJ+XQ==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.0.tgz",
+      "integrity": "sha512-Bb1NjZCaiwTQC/ARL+MwDpgocdnwWDCaugvkGt6cxfBzQa8Whv1JybBoUEiBDKl8Ni3H3c7Fykwk7QChUsHRlg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.6.4",
-        "@babel/helpers": "^7.6.2",
-        "@babel/parser": "^7.6.4",
-        "@babel/template": "^7.6.0",
-        "@babel/traverse": "^7.6.3",
-        "@babel/types": "^7.6.3",
+        "@babel/generator": "^7.7.0",
+        "@babel/helpers": "^7.7.0",
+        "@babel/parser": "^7.7.0",
+        "@babel/template": "^7.7.0",
+        "@babel/traverse": "^7.7.0",
+        "@babel/types": "^7.7.0",
         "convert-source-map": "^1.1.0",
         "debug": "^4.1.0",
         "json5": "^2.1.0",
@@ -45,64 +45,84 @@
           }
         },
         "@babel/generator": {
-          "version": "7.6.4",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
-          "integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.0.tgz",
+          "integrity": "sha512-1wdJ6UxHyL1XoJQ119JmvuRX27LRih7iYStMPZOWAjQqeAabFg3dYXKMpgihma+to+0ADsTVVt6oRyUxWZw6Mw==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.6.3",
+            "@babel/types": "^7.7.0",
             "jsesc": "^2.5.1",
             "lodash": "^4.17.13",
             "source-map": "^0.5.0"
           }
         },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.4.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-          "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+        "@babel/helper-function-name": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+          "integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.4.4"
+            "@babel/helper-get-function-arity": "^7.7.0",
+            "@babel/template": "^7.7.0",
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+          "integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
+          "integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.7.0"
           }
         },
         "@babel/parser": {
-          "version": "7.6.4",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
-          "integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.0.tgz",
+          "integrity": "sha512-GqL+Z0d7B7ADlQBMXlJgvXEbtt5qlqd1YQ5fr12hTSfh7O/vgrEIvJxU2e7aSVrEUn75zTZ6Nd0s8tthrlZnrQ==",
           "dev": true
         },
         "@babel/template": {
-          "version": "7.6.0",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
-          "integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+          "integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
-            "@babel/parser": "^7.6.0",
-            "@babel/types": "^7.6.0"
+            "@babel/parser": "^7.7.0",
+            "@babel/types": "^7.7.0"
           }
         },
         "@babel/traverse": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.3.tgz",
-          "integrity": "sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==",
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.0.tgz",
+          "integrity": "sha512-ea/3wRZc//e/uwCpuBX2itrhI0U9l7+FsrKWyKGNyvWbuMcCG7ATKY2VI4wlg2b2TA39HHwIxnvmXvtiKsyn7w==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.5.5",
-            "@babel/generator": "^7.6.3",
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.4.4",
-            "@babel/parser": "^7.6.3",
-            "@babel/types": "^7.6.3",
+            "@babel/generator": "^7.7.0",
+            "@babel/helper-function-name": "^7.7.0",
+            "@babel/helper-split-export-declaration": "^7.7.0",
+            "@babel/parser": "^7.7.0",
+            "@babel/types": "^7.7.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
             "lodash": "^4.17.13"
           }
         },
         "@babel/types": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
-          "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.1.tgz",
+          "integrity": "sha512-kN/XdANDab9x1z5gcjDc9ePpxexkt+1EQ2MQUiM4XnMvQfvp87/+6kY4Ko2maLXH+tei/DgJ/ybFITeqqRwDiA==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
@@ -184,14 +204,14 @@
       }
     },
     "@babel/helper-call-delegate": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
-      "integrity": "sha512-l79boDFJ8S1c5hvQvG+rc+wHw6IuH7YldmRKsYtpbawsxURu/paVy57FZMomGK22/JckepaikOkY0MoAmdyOlQ==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.7.0.tgz",
+      "integrity": "sha512-Su0Mdq7uSSWGZayGMMQ+z6lnL00mMCnGAbO/R0ZO9odIdB/WNU/VfQKqMQU0fdIsxQYbRjDM4BixIa93SQIpvw==",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "^7.4.4",
-        "@babel/traverse": "^7.4.4",
-        "@babel/types": "^7.4.4"
+        "@babel/helper-hoist-variables": "^7.7.0",
+        "@babel/traverse": "^7.7.0",
+        "@babel/types": "^7.7.0"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -204,53 +224,84 @@
           }
         },
         "@babel/generator": {
-          "version": "7.6.4",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
-          "integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.0.tgz",
+          "integrity": "sha512-1wdJ6UxHyL1XoJQ119JmvuRX27LRih7iYStMPZOWAjQqeAabFg3dYXKMpgihma+to+0ADsTVVt6oRyUxWZw6Mw==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.6.3",
+            "@babel/types": "^7.7.0",
             "jsesc": "^2.5.1",
             "lodash": "^4.17.13",
             "source-map": "^0.5.0"
           }
         },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.4.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-          "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+        "@babel/helper-function-name": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+          "integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.4.4"
+            "@babel/helper-get-function-arity": "^7.7.0",
+            "@babel/template": "^7.7.0",
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+          "integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
+          "integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.7.0"
           }
         },
         "@babel/parser": {
-          "version": "7.6.4",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
-          "integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.0.tgz",
+          "integrity": "sha512-GqL+Z0d7B7ADlQBMXlJgvXEbtt5qlqd1YQ5fr12hTSfh7O/vgrEIvJxU2e7aSVrEUn75zTZ6Nd0s8tthrlZnrQ==",
           "dev": true
         },
+        "@babel/template": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+          "integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/parser": "^7.7.0",
+            "@babel/types": "^7.7.0"
+          }
+        },
         "@babel/traverse": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.3.tgz",
-          "integrity": "sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==",
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.0.tgz",
+          "integrity": "sha512-ea/3wRZc//e/uwCpuBX2itrhI0U9l7+FsrKWyKGNyvWbuMcCG7ATKY2VI4wlg2b2TA39HHwIxnvmXvtiKsyn7w==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.5.5",
-            "@babel/generator": "^7.6.3",
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.4.4",
-            "@babel/parser": "^7.6.3",
-            "@babel/types": "^7.6.3",
+            "@babel/generator": "^7.7.0",
+            "@babel/helper-function-name": "^7.7.0",
+            "@babel/helper-split-export-declaration": "^7.7.0",
+            "@babel/parser": "^7.7.0",
+            "@babel/types": "^7.7.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
             "lodash": "^4.17.13"
           }
         },
         "@babel/types": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
-          "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.1.tgz",
+          "integrity": "sha512-kN/XdANDab9x1z5gcjDc9ePpxexkt+1EQ2MQUiM4XnMvQfvp87/+6kY4Ko2maLXH+tei/DgJ/ybFITeqqRwDiA==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
@@ -272,21 +323,85 @@
         }
       }
     },
-    "@babel/helper-define-map": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.5.5.tgz",
-      "integrity": "sha512-fTfxx7i0B5NJqvUOBBGREnrqbTxRh7zinBANpZXAVDlsZxYdclDp467G1sQ8VZYMnAURY3RpBUAgOYT9GfzHBg==",
+    "@babel/helper-create-regexp-features-plugin": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.7.0.tgz",
+      "integrity": "sha512-ZhagAAVGD3L6MPM9/zZi7RRteonfBFLVUz3kjsnYsMAtr9hOJCKI9BAKIMpqn3NyWicPieoX779UL+7/3BEAOA==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/types": "^7.5.5",
+        "@babel/helper-regex": "^7.4.4",
+        "regexpu-core": "^4.6.0"
+      },
+      "dependencies": {
+        "@babel/helper-regex": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
+          "integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.13"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-define-map": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.7.0.tgz",
+      "integrity": "sha512-kPKWPb0dMpZi+ov1hJiwse9dWweZsz3V9rP4KdytnX1E7z3cTNmFGglwklzFPuqIcHLIY3bgKSs4vkwXXdflQA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.7.0",
+        "@babel/types": "^7.7.0",
         "lodash": "^4.17.13"
       },
       "dependencies": {
+        "@babel/helper-function-name": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+          "integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.7.0",
+            "@babel/template": "^7.7.0",
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+          "integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.0.tgz",
+          "integrity": "sha512-GqL+Z0d7B7ADlQBMXlJgvXEbtt5qlqd1YQ5fr12hTSfh7O/vgrEIvJxU2e7aSVrEUn75zTZ6Nd0s8tthrlZnrQ==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+          "integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/parser": "^7.7.0",
+            "@babel/types": "^7.7.0"
+          }
+        },
         "@babel/types": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
-          "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.1.tgz",
+          "integrity": "sha512-kN/XdANDab9x1z5gcjDc9ePpxexkt+1EQ2MQUiM4XnMvQfvp87/+6kY4Ko2maLXH+tei/DgJ/ybFITeqqRwDiA==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
@@ -333,18 +448,18 @@
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz",
-      "integrity": "sha512-VYk2/H/BnYbZDDg39hr3t2kKyifAm1W6zHRfhx8jGjIHpQEBv9dry7oQ2f3+J703TLu69nYdxsovl0XYfcnK4w==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.7.0.tgz",
+      "integrity": "sha512-LUe/92NqsDAkJjjCEWkNe+/PcpnisvnqdlRe19FahVapa4jndeuJ+FBiTX1rcAKWKcJGE+C3Q3tuEuxkSmCEiQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.4.4"
+        "@babel/types": "^7.7.0"
       },
       "dependencies": {
         "@babel/types": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
-          "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.1.tgz",
+          "integrity": "sha512-kN/XdANDab9x1z5gcjDc9ePpxexkt+1EQ2MQUiM4XnMvQfvp87/+6kY4Ko2maLXH+tei/DgJ/ybFITeqqRwDiA==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
@@ -361,18 +476,18 @@
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz",
-      "integrity": "sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.7.0.tgz",
+      "integrity": "sha512-QaCZLO2RtBcmvO/ekOLp8p7R5X2JriKRizeDpm5ChATAFWrrYDcDxPuCIBXKyBjY+i1vYSdcUTMIb8psfxHDPA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.5.5"
+        "@babel/types": "^7.7.0"
       },
       "dependencies": {
         "@babel/types": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
-          "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.1.tgz",
+          "integrity": "sha512-kN/XdANDab9x1z5gcjDc9ePpxexkt+1EQ2MQUiM4XnMvQfvp87/+6kY4Ko2maLXH+tei/DgJ/ybFITeqqRwDiA==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
@@ -411,15 +526,6 @@
         "lodash": "^4.17.11"
       }
     },
-    "@babel/helper-optimise-call-expression": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
-      "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.0.0"
-      }
-    },
     "@babel/helper-plugin-utils": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
@@ -435,29 +541,16 @@
         "lodash": "^4.17.11"
       }
     },
-    "@babel/helper-remap-async-to-generator": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
-      "integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-annotate-as-pure": "^7.0.0",
-        "@babel/helper-wrap-function": "^7.1.0",
-        "@babel/template": "^7.1.0",
-        "@babel/traverse": "^7.1.0",
-        "@babel/types": "^7.0.0"
-      }
-    },
     "@babel/helper-replace-supers": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz",
-      "integrity": "sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.7.0.tgz",
+      "integrity": "sha512-5ALYEul5V8xNdxEeWvRsBzLMxQksT7MaStpxjJf9KsnLxpAKBtfw5NeMKZJSYDa0lKdOcy0g+JT/f5mPSulUgg==",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.5.5",
-        "@babel/helper-optimise-call-expression": "^7.0.0",
-        "@babel/traverse": "^7.5.5",
-        "@babel/types": "^7.5.5"
+        "@babel/helper-member-expression-to-functions": "^7.7.0",
+        "@babel/helper-optimise-call-expression": "^7.7.0",
+        "@babel/traverse": "^7.7.0",
+        "@babel/types": "^7.7.0"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -470,53 +563,93 @@
           }
         },
         "@babel/generator": {
-          "version": "7.6.4",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
-          "integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.0.tgz",
+          "integrity": "sha512-1wdJ6UxHyL1XoJQ119JmvuRX27LRih7iYStMPZOWAjQqeAabFg3dYXKMpgihma+to+0ADsTVVt6oRyUxWZw6Mw==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.6.3",
+            "@babel/types": "^7.7.0",
             "jsesc": "^2.5.1",
             "lodash": "^4.17.13",
             "source-map": "^0.5.0"
           }
         },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.4.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-          "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+        "@babel/helper-function-name": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+          "integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.4.4"
+            "@babel/helper-get-function-arity": "^7.7.0",
+            "@babel/template": "^7.7.0",
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+          "integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/helper-optimise-call-expression": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.7.0.tgz",
+          "integrity": "sha512-48TeqmbazjNU/65niiiJIJRc5JozB8acui1OS7bSd6PgxfuovWsvjfWSzlgx+gPFdVveNzUdpdIg5l56Pl5jqg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
+          "integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.7.0"
           }
         },
         "@babel/parser": {
-          "version": "7.6.4",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
-          "integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.0.tgz",
+          "integrity": "sha512-GqL+Z0d7B7ADlQBMXlJgvXEbtt5qlqd1YQ5fr12hTSfh7O/vgrEIvJxU2e7aSVrEUn75zTZ6Nd0s8tthrlZnrQ==",
           "dev": true
         },
+        "@babel/template": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+          "integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/parser": "^7.7.0",
+            "@babel/types": "^7.7.0"
+          }
+        },
         "@babel/traverse": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.3.tgz",
-          "integrity": "sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==",
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.0.tgz",
+          "integrity": "sha512-ea/3wRZc//e/uwCpuBX2itrhI0U9l7+FsrKWyKGNyvWbuMcCG7ATKY2VI4wlg2b2TA39HHwIxnvmXvtiKsyn7w==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.5.5",
-            "@babel/generator": "^7.6.3",
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.4.4",
-            "@babel/parser": "^7.6.3",
-            "@babel/types": "^7.6.3",
+            "@babel/generator": "^7.7.0",
+            "@babel/helper-function-name": "^7.7.0",
+            "@babel/helper-split-export-declaration": "^7.7.0",
+            "@babel/parser": "^7.7.0",
+            "@babel/types": "^7.7.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
             "lodash": "^4.17.13"
           }
         },
         "@babel/types": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
-          "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.1.tgz",
+          "integrity": "sha512-kN/XdANDab9x1z5gcjDc9ePpxexkt+1EQ2MQUiM4XnMvQfvp87/+6kY4Ko2maLXH+tei/DgJ/ybFITeqqRwDiA==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
@@ -570,79 +703,87 @@
         }
       }
     },
-    "@babel/helper-wrap-function": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
-      "integrity": "sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/template": "^7.1.0",
-        "@babel/traverse": "^7.1.0",
-        "@babel/types": "^7.2.0"
-      }
-    },
     "@babel/helpers": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.2.tgz",
-      "integrity": "sha512-3/bAUL8zZxYs1cdX2ilEE0WobqbCmKWr/889lf2SS0PpDcpEIY8pb1CCyz0pEcX3pEb+MCbks1jIokz2xLtGTA==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.7.0.tgz",
+      "integrity": "sha512-VnNwL4YOhbejHb7x/b5F39Zdg5vIQpUUNzJwx0ww1EcVRt41bbGRZWhAURrfY32T5zTT3qwNOQFWpn+P0i0a2g==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.6.0",
-        "@babel/traverse": "^7.6.2",
-        "@babel/types": "^7.6.0"
+        "@babel/template": "^7.7.0",
+        "@babel/traverse": "^7.7.0",
+        "@babel/types": "^7.7.0"
       },
       "dependencies": {
         "@babel/generator": {
-          "version": "7.6.4",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
-          "integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.0.tgz",
+          "integrity": "sha512-1wdJ6UxHyL1XoJQ119JmvuRX27LRih7iYStMPZOWAjQqeAabFg3dYXKMpgihma+to+0ADsTVVt6oRyUxWZw6Mw==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.6.3",
+            "@babel/types": "^7.7.0",
             "jsesc": "^2.5.1",
             "lodash": "^4.17.13",
             "source-map": "^0.5.0"
           }
         },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.4.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-          "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+        "@babel/helper-function-name": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+          "integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.4.4"
+            "@babel/helper-get-function-arity": "^7.7.0",
+            "@babel/template": "^7.7.0",
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+          "integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
+          "integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.7.0"
           }
         },
         "@babel/parser": {
-          "version": "7.6.4",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
-          "integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.0.tgz",
+          "integrity": "sha512-GqL+Z0d7B7ADlQBMXlJgvXEbtt5qlqd1YQ5fr12hTSfh7O/vgrEIvJxU2e7aSVrEUn75zTZ6Nd0s8tthrlZnrQ==",
           "dev": true
         },
         "@babel/template": {
-          "version": "7.6.0",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
-          "integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+          "integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
-            "@babel/parser": "^7.6.0",
-            "@babel/types": "^7.6.0"
+            "@babel/parser": "^7.7.0",
+            "@babel/types": "^7.7.0"
           }
         },
         "@babel/traverse": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.3.tgz",
-          "integrity": "sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==",
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.0.tgz",
+          "integrity": "sha512-ea/3wRZc//e/uwCpuBX2itrhI0U9l7+FsrKWyKGNyvWbuMcCG7ATKY2VI4wlg2b2TA39HHwIxnvmXvtiKsyn7w==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.5.5",
-            "@babel/generator": "^7.6.3",
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.4.4",
-            "@babel/parser": "^7.6.3",
-            "@babel/types": "^7.6.3",
+            "@babel/generator": "^7.7.0",
+            "@babel/helper-function-name": "^7.7.0",
+            "@babel/helper-split-export-declaration": "^7.7.0",
+            "@babel/parser": "^7.7.0",
+            "@babel/types": "^7.7.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
             "lodash": "^4.17.13"
@@ -660,9 +801,9 @@
           }
         },
         "@babel/types": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
-          "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.1.tgz",
+          "integrity": "sha512-kN/XdANDab9x1z5gcjDc9ePpxexkt+1EQ2MQUiM4XnMvQfvp87/+6kY4Ko2maLXH+tei/DgJ/ybFITeqqRwDiA==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
@@ -701,27 +842,6 @@
       "integrity": "sha512-tXZCqWtlOOP4wgCp6RjRvLmfuhnqTLy9VHwRochJBCP2nDm27JnnuFEnXFASVyQNHk36jD1tAammsCEEqgscIQ==",
       "dev": true
     },
-    "@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
-      "integrity": "sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-remap-async-to-generator": "^7.1.0",
-        "@babel/plugin-syntax-async-generators": "^7.2.0"
-      }
-    },
-    "@babel/plugin-proposal-dynamic-import": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.5.0.tgz",
-      "integrity": "sha512-x/iMjggsKTFHYC6g11PL7Qy58IK8H5zqfm9e6hu4z1iH2IRyAp9u9dL80zA6R76yFovETFLKz2VJIC2iIPBuFw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-dynamic-import": "^7.2.0"
-      }
-    },
     "@babel/plugin-proposal-json-strings": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz",
@@ -753,31 +873,13 @@
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.6.2.tgz",
-      "integrity": "sha512-NxHETdmpeSCtiatMRYWVJo7266rrvAC3DTeG5exQBIH/fMIUK7ejDNznBbn3HQl/o9peymRRg7Yqkx6PdUXmMw==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.7.0.tgz",
+      "integrity": "sha512-mk34H+hp7kRBWJOOAR0ZMGCydgKMD4iN9TpDRp3IIcbunltxEY89XSimc6WbtSLCDrwcdy/EEw7h5CFCzxTchw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.4.4",
-        "regexpu-core": "^4.6.0"
-      },
-      "dependencies": {
-        "@babel/helper-regex": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
-          "integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.13"
-          }
-        },
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-          "dev": true
-        }
+        "@babel/helper-create-regexp-features-plugin": "^7.7.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-syntax-async-generators": {
@@ -843,6 +945,15 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-syntax-top-level-await": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.7.0.tgz",
+      "integrity": "sha512-hi8FUNiFIY1fnUI2n1ViB1DR0R4QeK4iHcTlW6aJkrPoTdb8Rf1EMQ6GT3f67DDkYyWgew9DFoOZ6gOoEsdzTA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
     "@babel/plugin-transform-arrow-functions": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
@@ -853,14 +964,168 @@
       }
     },
     "@babel/plugin-transform-async-to-generator": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.5.0.tgz",
-      "integrity": "sha512-mqvkzwIGkq0bEF1zLRRiTdjfomZJDV33AH3oQzHVGkI2VzEmXLpKKOBvEVaFZBJdN0XTyH38s9j/Kiqr68dggg==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.7.0.tgz",
+      "integrity": "sha512-vLI2EFLVvRBL3d8roAMqtVY0Bm9C1QzLkdS57hiKrjUBSqsQYrBsMCeOg/0KK7B0eK9V71J5mWcha9yyoI2tZw==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-module-imports": "^7.7.0",
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-remap-async-to-generator": "^7.1.0"
+        "@babel/helper-remap-async-to-generator": "^7.7.0"
+      },
+      "dependencies": {
+        "@babel/generator": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.0.tgz",
+          "integrity": "sha512-1wdJ6UxHyL1XoJQ119JmvuRX27LRih7iYStMPZOWAjQqeAabFg3dYXKMpgihma+to+0ADsTVVt6oRyUxWZw6Mw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.7.0",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-annotate-as-pure": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.7.0.tgz",
+          "integrity": "sha512-k50CQxMlYTYo+GGyUGFwpxKVtxVJi9yh61sXZji3zYHccK9RYliZGSTOgci85T+r+0VFN2nWbGM04PIqwfrpMg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+          "integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.7.0",
+            "@babel/template": "^7.7.0",
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+          "integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/helper-module-imports": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.7.0.tgz",
+          "integrity": "sha512-Dv3hLKIC1jyfTkClvyEkYP2OlkzNvWs5+Q8WgPbxM5LMeorons7iPP91JM+DU7tRbhqA1ZeooPaMFvQrn23RHw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/helper-remap-async-to-generator": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.7.0.tgz",
+          "integrity": "sha512-pHx7RN8X0UNHPB/fnuDnRXVZ316ZigkO8y8D835JlZ2SSdFKb6yH9MIYRU4fy/KPe5sPHDFOPvf8QLdbAGGiyw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.7.0",
+            "@babel/helper-wrap-function": "^7.7.0",
+            "@babel/template": "^7.7.0",
+            "@babel/traverse": "^7.7.0",
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
+          "integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/helper-wrap-function": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.7.0.tgz",
+          "integrity": "sha512-sd4QjeMgQqzshSjecZjOp8uKfUtnpmCyQhKQrVJBBgeHAB/0FPi33h3AbVlVp07qQtMD4QgYSzaMI7VwncNK/w==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-function-name": "^7.7.0",
+            "@babel/template": "^7.7.0",
+            "@babel/traverse": "^7.7.0",
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.0.tgz",
+          "integrity": "sha512-GqL+Z0d7B7ADlQBMXlJgvXEbtt5qlqd1YQ5fr12hTSfh7O/vgrEIvJxU2e7aSVrEUn75zTZ6Nd0s8tthrlZnrQ==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+          "integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/parser": "^7.7.0",
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.0.tgz",
+          "integrity": "sha512-ea/3wRZc//e/uwCpuBX2itrhI0U9l7+FsrKWyKGNyvWbuMcCG7ATKY2VI4wlg2b2TA39HHwIxnvmXvtiKsyn7w==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.5.5",
+            "@babel/generator": "^7.7.0",
+            "@babel/helper-function-name": "^7.7.0",
+            "@babel/helper-split-export-declaration": "^7.7.0",
+            "@babel/parser": "^7.7.0",
+            "@babel/types": "^7.7.0",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+          },
+          "dependencies": {
+            "@babel/code-frame": {
+              "version": "7.5.5",
+              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+              "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+              "dev": true,
+              "requires": {
+                "@babel/highlight": "^7.0.0"
+              }
+            }
+          }
+        },
+        "@babel/types": {
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.1.tgz",
+          "integrity": "sha512-kN/XdANDab9x1z5gcjDc9ePpxexkt+1EQ2MQUiM4XnMvQfvp87/+6kY4Ko2maLXH+tei/DgJ/ybFITeqqRwDiA==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
       }
     },
     "@babel/plugin-transform-block-scoped-functions": {
@@ -891,34 +1156,89 @@
       }
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.5.5.tgz",
-      "integrity": "sha512-U2htCNK/6e9K7jGyJ++1p5XRU+LJjrwtoiVn9SzRlDT2KubcZ11OOwy3s24TjHxPgxNwonCYP7U2K51uVYCMDg==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.7.0.tgz",
+      "integrity": "sha512-/b3cKIZwGeUesZheU9jNYcwrEA7f/Bo4IdPmvp7oHgvks2majB5BoT5byAql44fiNQYOPzhk2w8DbgfuafkMoA==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.0.0",
-        "@babel/helper-define-map": "^7.5.5",
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-optimise-call-expression": "^7.0.0",
+        "@babel/helper-annotate-as-pure": "^7.7.0",
+        "@babel/helper-define-map": "^7.7.0",
+        "@babel/helper-function-name": "^7.7.0",
+        "@babel/helper-optimise-call-expression": "^7.7.0",
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.5.5",
-        "@babel/helper-split-export-declaration": "^7.4.4",
+        "@babel/helper-replace-supers": "^7.7.0",
+        "@babel/helper-split-export-declaration": "^7.7.0",
         "globals": "^11.1.0"
       },
       "dependencies": {
-        "@babel/helper-split-export-declaration": {
-          "version": "7.4.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-          "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+        "@babel/helper-annotate-as-pure": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.7.0.tgz",
+          "integrity": "sha512-k50CQxMlYTYo+GGyUGFwpxKVtxVJi9yh61sXZji3zYHccK9RYliZGSTOgci85T+r+0VFN2nWbGM04PIqwfrpMg==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.4.4"
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+          "integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.7.0",
+            "@babel/template": "^7.7.0",
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+          "integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/helper-optimise-call-expression": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.7.0.tgz",
+          "integrity": "sha512-48TeqmbazjNU/65niiiJIJRc5JozB8acui1OS7bSd6PgxfuovWsvjfWSzlgx+gPFdVveNzUdpdIg5l56Pl5jqg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
+          "integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.0.tgz",
+          "integrity": "sha512-GqL+Z0d7B7ADlQBMXlJgvXEbtt5qlqd1YQ5fr12hTSfh7O/vgrEIvJxU2e7aSVrEUn75zTZ6Nd0s8tthrlZnrQ==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+          "integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/parser": "^7.7.0",
+            "@babel/types": "^7.7.0"
           }
         },
         "@babel/types": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
-          "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.1.tgz",
+          "integrity": "sha512-kN/XdANDab9x1z5gcjDc9ePpxexkt+1EQ2MQUiM4XnMvQfvp87/+6kY4Ko2maLXH+tei/DgJ/ybFITeqqRwDiA==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
@@ -953,31 +1273,13 @@
       }
     },
     "@babel/plugin-transform-dotall-regex": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.6.2.tgz",
-      "integrity": "sha512-KGKT9aqKV+9YMZSkowzYoYEiHqgaDhGmPNZlZxX6UeHC4z30nC1J9IrZuGqbYFB1jaIGdv91ujpze0exiVK8bA==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.7.0.tgz",
+      "integrity": "sha512-3QQlF7hSBnSuM1hQ0pS3pmAbWLax/uGNCbPBND9y+oJ4Y776jsyujG2k0Sn2Aj2a0QwVOiOFL5QVPA7spjvzSA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.4.4",
-        "regexpu-core": "^4.6.0"
-      },
-      "dependencies": {
-        "@babel/helper-regex": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
-          "integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.13"
-          }
-        },
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-          "dev": true
-        }
+        "@babel/helper-create-regexp-features-plugin": "^7.7.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-duplicate-keys": {
@@ -1019,13 +1321,69 @@
       }
     },
     "@babel/plugin-transform-function-name": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz",
-      "integrity": "sha512-iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.7.0.tgz",
+      "integrity": "sha512-P5HKu0d9+CzZxP5jcrWdpe7ZlFDe24bmqP6a6X8BHEBl/eizAsY8K6LX8LASZL0Jxdjm5eEfzp+FIrxCm/p8bA==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-function-name": "^7.7.0",
         "@babel/helper-plugin-utils": "^7.0.0"
+      },
+      "dependencies": {
+        "@babel/helper-function-name": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+          "integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.7.0",
+            "@babel/template": "^7.7.0",
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+          "integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.0.tgz",
+          "integrity": "sha512-GqL+Z0d7B7ADlQBMXlJgvXEbtt5qlqd1YQ5fr12hTSfh7O/vgrEIvJxU2e7aSVrEUn75zTZ6Nd0s8tthrlZnrQ==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+          "integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/parser": "^7.7.0",
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.1.tgz",
+          "integrity": "sha512-kN/XdANDab9x1z5gcjDc9ePpxexkt+1EQ2MQUiM4XnMvQfvp87/+6kY4Ko2maLXH+tei/DgJ/ybFITeqqRwDiA==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "@babel/plugin-transform-literals": {
@@ -1058,61 +1416,80 @@
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.6.0.tgz",
-      "integrity": "sha512-Ma93Ix95PNSEngqomy5LSBMAQvYKVe3dy+JlVJSHEXZR5ASL9lQBedMiCyVtmTLraIDVRE3ZjTZvmXXD2Ozw3g==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.7.0.tgz",
+      "integrity": "sha512-KEMyWNNWnjOom8vR/1+d+Ocz/mILZG/eyHHO06OuBQ2aNhxT62fr4y6fGOplRx+CxCSp3IFwesL8WdINfY/3kg==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.4.4",
+        "@babel/helper-module-transforms": "^7.7.0",
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-simple-access": "^7.1.0",
+        "@babel/helper-simple-access": "^7.7.0",
         "babel-plugin-dynamic-import-node": "^2.3.0"
       },
       "dependencies": {
-        "@babel/helper-module-transforms": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.5.5.tgz",
-          "integrity": "sha512-jBeCvETKuJqeiaCdyaheF40aXnnU1+wkSiUs/IQg3tB85up1LyL8x77ClY8qJpuRJUcXQo+ZtdNESmZl4j56Pw==",
+        "@babel/helper-module-imports": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.7.0.tgz",
+          "integrity": "sha512-Dv3hLKIC1jyfTkClvyEkYP2OlkzNvWs5+Q8WgPbxM5LMeorons7iPP91JM+DU7tRbhqA1ZeooPaMFvQrn23RHw==",
           "dev": true,
           "requires": {
-            "@babel/helper-module-imports": "^7.0.0",
-            "@babel/helper-simple-access": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.4.4",
-            "@babel/template": "^7.4.4",
-            "@babel/types": "^7.5.5",
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/helper-module-transforms": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.7.0.tgz",
+          "integrity": "sha512-rXEefBuheUYQyX4WjV19tuknrJFwyKw0HgzRwbkyTbB+Dshlq7eqkWbyjzToLrMZk/5wKVKdWFluiAsVkHXvuQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.7.0",
+            "@babel/helper-simple-access": "^7.7.0",
+            "@babel/helper-split-export-declaration": "^7.7.0",
+            "@babel/template": "^7.7.0",
+            "@babel/types": "^7.7.0",
             "lodash": "^4.17.13"
           }
         },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.4.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-          "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+        "@babel/helper-simple-access": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.7.0.tgz",
+          "integrity": "sha512-AJ7IZD7Eem3zZRuj5JtzFAptBw7pMlS3y8Qv09vaBWoFsle0d1kAn5Wq6Q9MyBXITPOKnxwkZKoAm4bopmv26g==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.4.4"
+            "@babel/template": "^7.7.0",
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
+          "integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.7.0"
           }
         },
         "@babel/parser": {
-          "version": "7.6.4",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
-          "integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.0.tgz",
+          "integrity": "sha512-GqL+Z0d7B7ADlQBMXlJgvXEbtt5qlqd1YQ5fr12hTSfh7O/vgrEIvJxU2e7aSVrEUn75zTZ6Nd0s8tthrlZnrQ==",
           "dev": true
         },
         "@babel/template": {
-          "version": "7.6.0",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
-          "integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+          "integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
-            "@babel/parser": "^7.6.0",
-            "@babel/types": "^7.6.0"
+            "@babel/parser": "^7.7.0",
+            "@babel/types": "^7.7.0"
           }
         },
         "@babel/types": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
-          "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.1.tgz",
+          "integrity": "sha512-kN/XdANDab9x1z5gcjDc9ePpxexkt+1EQ2MQUiM4XnMvQfvp87/+6kY4Ko2maLXH+tei/DgJ/ybFITeqqRwDiA==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
@@ -1129,33 +1506,23 @@
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.5.0.tgz",
-      "integrity": "sha512-Q2m56tyoQWmuNGxEtUyeEkm6qJYFqs4c+XyXH5RAuYxObRNz9Zgj/1g2GMnjYp2EUyEy7YTrxliGCXzecl/vJg==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.7.0.tgz",
+      "integrity": "sha512-ZAuFgYjJzDNv77AjXRqzQGlQl4HdUM6j296ee4fwKVZfhDR9LAGxfvXjBkb06gNETPnN0sLqRm9Gxg4wZH6dXg==",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "^7.4.4",
+        "@babel/helper-hoist-variables": "^7.7.0",
         "@babel/helper-plugin-utils": "^7.0.0",
         "babel-plugin-dynamic-import-node": "^2.3.0"
       }
     },
-    "@babel/plugin-transform-modules-umd": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz",
-      "integrity": "sha512-BV3bw6MyUH1iIsGhXlOK6sXhmSarZjtJ/vMiD9dNmpY8QXFFQTj+6v92pcfy1iqa8DeAfJFwoxcrS/TUZda6sw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-module-transforms": "^7.1.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
-      }
-    },
     "@babel/plugin-transform-named-capturing-groups-regex": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.6.3.tgz",
-      "integrity": "sha512-jTkk7/uE6H2s5w6VlMHeWuH+Pcy2lmdwFoeWCVnvIrDUnB5gQqTVI8WfmEAhF2CDEarGrknZcmSFg1+bkfCoSw==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.7.0.tgz",
+      "integrity": "sha512-+SicSJoKouPctL+j1pqktRVCgy+xAch1hWWTMy13j0IflnyNjaoskj+DwRQFimHbLqO3sq2oN2CXMvXq3Bgapg==",
       "dev": true,
       "requires": {
-        "regexpu-core": "^4.6.0"
+        "@babel/helper-create-regexp-features-plugin": "^7.7.0"
       }
     },
     "@babel/plugin-transform-new-target": {
@@ -1209,9 +1576,9 @@
       }
     },
     "@babel/plugin-transform-regenerator": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz",
-      "integrity": "sha512-gBKRh5qAaCWntnd09S8QC7r3auLCqq5DI6O0DlfoyDjslSBVqBibrMdsqO+Uhmx3+BlOmE/Kw1HFxmGbv0N9dA==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.7.0.tgz",
+      "integrity": "sha512-AXmvnC+0wuj/cFkkS/HFHIojxH3ffSXE+ttulrqWjZZRaUOonfJc60e1wSNT4rV8tIunvu/R3wCp71/tLAa9xg==",
       "dev": true,
       "requires": {
         "regenerator-transform": "^0.14.0"
@@ -1274,84 +1641,67 @@
       }
     },
     "@babel/plugin-transform-unicode-regex": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.6.2.tgz",
-      "integrity": "sha512-orZI6cWlR3nk2YmYdb0gImrgCUwb5cBUwjf6Ks6dvNVvXERkwtJWOQaEOjPiu0Gu1Tq6Yq/hruCZZOOi9F34Dw==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.7.0.tgz",
+      "integrity": "sha512-RrThb0gdrNwFAqEAAx9OWgtx6ICK69x7i9tCnMdVrxQwSDp/Abu9DXFU5Hh16VP33Rmxh04+NGW28NsIkFvFKA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.4.4",
-        "regexpu-core": "^4.6.0"
-      },
-      "dependencies": {
-        "@babel/helper-regex": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
-          "integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.13"
-          }
-        },
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-          "dev": true
-        }
+        "@babel/helper-create-regexp-features-plugin": "^7.7.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/preset-env": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.6.3.tgz",
-      "integrity": "sha512-CWQkn7EVnwzlOdR5NOm2+pfgSNEZmvGjOhlCHBDq0J8/EStr+G+FvPEiz9B56dR6MoiUFjXhfE4hjLoAKKJtIQ==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.7.1.tgz",
+      "integrity": "sha512-/93SWhi3PxcVTDpSqC+Dp4YxUu3qZ4m7I76k0w73wYfn7bGVuRIO4QUz95aJksbS+AD1/mT1Ie7rbkT0wSplaA==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-module-imports": "^7.7.0",
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
-        "@babel/plugin-proposal-dynamic-import": "^7.5.0",
+        "@babel/plugin-proposal-async-generator-functions": "^7.7.0",
+        "@babel/plugin-proposal-dynamic-import": "^7.7.0",
         "@babel/plugin-proposal-json-strings": "^7.2.0",
         "@babel/plugin-proposal-object-rest-spread": "^7.6.2",
         "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
-        "@babel/plugin-proposal-unicode-property-regex": "^7.6.2",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.7.0",
         "@babel/plugin-syntax-async-generators": "^7.2.0",
         "@babel/plugin-syntax-dynamic-import": "^7.2.0",
         "@babel/plugin-syntax-json-strings": "^7.2.0",
         "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
         "@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
+        "@babel/plugin-syntax-top-level-await": "^7.7.0",
         "@babel/plugin-transform-arrow-functions": "^7.2.0",
-        "@babel/plugin-transform-async-to-generator": "^7.5.0",
+        "@babel/plugin-transform-async-to-generator": "^7.7.0",
         "@babel/plugin-transform-block-scoped-functions": "^7.2.0",
         "@babel/plugin-transform-block-scoping": "^7.6.3",
-        "@babel/plugin-transform-classes": "^7.5.5",
+        "@babel/plugin-transform-classes": "^7.7.0",
         "@babel/plugin-transform-computed-properties": "^7.2.0",
         "@babel/plugin-transform-destructuring": "^7.6.0",
-        "@babel/plugin-transform-dotall-regex": "^7.6.2",
+        "@babel/plugin-transform-dotall-regex": "^7.7.0",
         "@babel/plugin-transform-duplicate-keys": "^7.5.0",
         "@babel/plugin-transform-exponentiation-operator": "^7.2.0",
         "@babel/plugin-transform-for-of": "^7.4.4",
-        "@babel/plugin-transform-function-name": "^7.4.4",
+        "@babel/plugin-transform-function-name": "^7.7.0",
         "@babel/plugin-transform-literals": "^7.2.0",
         "@babel/plugin-transform-member-expression-literals": "^7.2.0",
         "@babel/plugin-transform-modules-amd": "^7.5.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.6.0",
-        "@babel/plugin-transform-modules-systemjs": "^7.5.0",
-        "@babel/plugin-transform-modules-umd": "^7.2.0",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.6.3",
+        "@babel/plugin-transform-modules-commonjs": "^7.7.0",
+        "@babel/plugin-transform-modules-systemjs": "^7.7.0",
+        "@babel/plugin-transform-modules-umd": "^7.7.0",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.7.0",
         "@babel/plugin-transform-new-target": "^7.4.4",
         "@babel/plugin-transform-object-super": "^7.5.5",
         "@babel/plugin-transform-parameters": "^7.4.4",
         "@babel/plugin-transform-property-literals": "^7.2.0",
-        "@babel/plugin-transform-regenerator": "^7.4.5",
+        "@babel/plugin-transform-regenerator": "^7.7.0",
         "@babel/plugin-transform-reserved-words": "^7.2.0",
         "@babel/plugin-transform-shorthand-properties": "^7.2.0",
         "@babel/plugin-transform-spread": "^7.6.2",
         "@babel/plugin-transform-sticky-regex": "^7.2.0",
         "@babel/plugin-transform-template-literals": "^7.4.4",
         "@babel/plugin-transform-typeof-symbol": "^7.2.0",
-        "@babel/plugin-transform-unicode-regex": "^7.6.2",
-        "@babel/types": "^7.6.3",
+        "@babel/plugin-transform-unicode-regex": "^7.7.0",
+        "@babel/types": "^7.7.1",
         "browserslist": "^4.6.0",
         "core-js-compat": "^3.1.1",
         "invariant": "^2.2.2",
@@ -1359,10 +1709,194 @@
         "semver": "^5.5.0"
       },
       "dependencies": {
+        "@babel/generator": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.0.tgz",
+          "integrity": "sha512-1wdJ6UxHyL1XoJQ119JmvuRX27LRih7iYStMPZOWAjQqeAabFg3dYXKMpgihma+to+0ADsTVVt6oRyUxWZw6Mw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.7.0",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-annotate-as-pure": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.7.0.tgz",
+          "integrity": "sha512-k50CQxMlYTYo+GGyUGFwpxKVtxVJi9yh61sXZji3zYHccK9RYliZGSTOgci85T+r+0VFN2nWbGM04PIqwfrpMg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+          "integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.7.0",
+            "@babel/template": "^7.7.0",
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+          "integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/helper-module-imports": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.7.0.tgz",
+          "integrity": "sha512-Dv3hLKIC1jyfTkClvyEkYP2OlkzNvWs5+Q8WgPbxM5LMeorons7iPP91JM+DU7tRbhqA1ZeooPaMFvQrn23RHw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/helper-module-transforms": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.7.0.tgz",
+          "integrity": "sha512-rXEefBuheUYQyX4WjV19tuknrJFwyKw0HgzRwbkyTbB+Dshlq7eqkWbyjzToLrMZk/5wKVKdWFluiAsVkHXvuQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.7.0",
+            "@babel/helper-simple-access": "^7.7.0",
+            "@babel/helper-split-export-declaration": "^7.7.0",
+            "@babel/template": "^7.7.0",
+            "@babel/types": "^7.7.0",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/helper-remap-async-to-generator": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.7.0.tgz",
+          "integrity": "sha512-pHx7RN8X0UNHPB/fnuDnRXVZ316ZigkO8y8D835JlZ2SSdFKb6yH9MIYRU4fy/KPe5sPHDFOPvf8QLdbAGGiyw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.7.0",
+            "@babel/helper-wrap-function": "^7.7.0",
+            "@babel/template": "^7.7.0",
+            "@babel/traverse": "^7.7.0",
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/helper-simple-access": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.7.0.tgz",
+          "integrity": "sha512-AJ7IZD7Eem3zZRuj5JtzFAptBw7pMlS3y8Qv09vaBWoFsle0d1kAn5Wq6Q9MyBXITPOKnxwkZKoAm4bopmv26g==",
+          "dev": true,
+          "requires": {
+            "@babel/template": "^7.7.0",
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
+          "integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/helper-wrap-function": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.7.0.tgz",
+          "integrity": "sha512-sd4QjeMgQqzshSjecZjOp8uKfUtnpmCyQhKQrVJBBgeHAB/0FPi33h3AbVlVp07qQtMD4QgYSzaMI7VwncNK/w==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-function-name": "^7.7.0",
+            "@babel/template": "^7.7.0",
+            "@babel/traverse": "^7.7.0",
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.0.tgz",
+          "integrity": "sha512-GqL+Z0d7B7ADlQBMXlJgvXEbtt5qlqd1YQ5fr12hTSfh7O/vgrEIvJxU2e7aSVrEUn75zTZ6Nd0s8tthrlZnrQ==",
+          "dev": true
+        },
+        "@babel/plugin-proposal-async-generator-functions": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.7.0.tgz",
+          "integrity": "sha512-ot/EZVvf3mXtZq0Pd0+tSOfGWMizqmOohXmNZg6LNFjHOV+wOPv7BvVYh8oPR8LhpIP3ye8nNooKL50YRWxpYA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-remap-async-to-generator": "^7.7.0",
+            "@babel/plugin-syntax-async-generators": "^7.2.0"
+          }
+        },
+        "@babel/plugin-proposal-dynamic-import": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.7.0.tgz",
+          "integrity": "sha512-7poL3Xi+QFPC7sGAzEIbXUyYzGJwbc2+gSD0AkiC5k52kH2cqHdqxm5hNFfLW3cRSTcx9bN0Fl7/6zWcLLnKAQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-dynamic-import": "^7.2.0"
+          }
+        },
+        "@babel/plugin-transform-modules-umd": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.7.0.tgz",
+          "integrity": "sha512-u7eBA03zmUswQ9LQ7Qw0/ieC1pcAkbp5OQatbWUzY1PaBccvuJXUkYzoN1g7cqp7dbTu6Dp9bXyalBvD04AANA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-transforms": "^7.7.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/template": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+          "integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/parser": "^7.7.0",
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.0.tgz",
+          "integrity": "sha512-ea/3wRZc//e/uwCpuBX2itrhI0U9l7+FsrKWyKGNyvWbuMcCG7ATKY2VI4wlg2b2TA39HHwIxnvmXvtiKsyn7w==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.5.5",
+            "@babel/generator": "^7.7.0",
+            "@babel/helper-function-name": "^7.7.0",
+            "@babel/helper-split-export-declaration": "^7.7.0",
+            "@babel/parser": "^7.7.0",
+            "@babel/types": "^7.7.0",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+          },
+          "dependencies": {
+            "@babel/code-frame": {
+              "version": "7.5.5",
+              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+              "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+              "dev": true,
+              "requires": {
+                "@babel/highlight": "^7.0.0"
+              }
+            }
+          }
+        },
         "@babel/types": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
-          "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.1.tgz",
+          "integrity": "sha512-kN/XdANDab9x1z5gcjDc9ePpxexkt+1EQ2MQUiM4XnMvQfvp87/+6kY4Ko2maLXH+tei/DgJ/ybFITeqqRwDiA==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
@@ -1388,9 +1922,9 @@
           "dev": true
         },
         "electron-to-chromium": {
-          "version": "1.3.302",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.302.tgz",
-          "integrity": "sha512-1qConyiVEbj4xZRBXqtGR003+9tV0rJF0PS6aeO0Ln/UL637js9hdwweCl07meh/kJoI2N4W8q3R3g3F5z46ww==",
+          "version": "1.3.304",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.304.tgz",
+          "integrity": "sha512-a5mqa13jCdBc+Crgk3Gyr7vpXCiFWfFq23YDCEmrPYeiDOQKZDVE6EX/Q4Xdv97n3XkcjiSBDOY0IS19yP2yeA==",
           "dev": true
         },
         "lodash": {
@@ -1415,13 +1949,19 @@
               "dev": true
             }
           }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
         }
       }
     },
     "@babel/runtime": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
-      "integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.1.tgz",
+      "integrity": "sha512-SQ0sS7KUJDvgCI2cpZG0nJygO6002oTbhgSuw4WcocsnbxLwL5Q8I3fqbJdyBAc3uFrWZiR2JomseuxSuci3SQ==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.2"
@@ -5520,714 +6060,10 @@
       "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
       "dev": true
     },
-    "parcel": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/parcel/-/parcel-1.12.4.tgz",
-      "integrity": "sha512-qfc74e2/R4pCoU6L/ZZnK9k3iDS6ir4uHea0e9th9w52eehcAGf2ido/iABq9PBXdsIOe4NSY3oUm7Khe7+S3w==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/core": "^7.4.4",
-        "@babel/generator": "^7.4.4",
-        "@babel/parser": "^7.4.4",
-        "@babel/plugin-transform-flow-strip-types": "^7.4.4",
-        "@babel/plugin-transform-modules-commonjs": "^7.4.4",
-        "@babel/plugin-transform-react-jsx": "^7.0.0",
-        "@babel/preset-env": "^7.4.4",
-        "@babel/runtime": "^7.4.4",
-        "@babel/template": "^7.4.4",
-        "@babel/traverse": "^7.4.4",
-        "@babel/types": "^7.4.4",
-        "@iarna/toml": "^2.2.0",
-        "@parcel/fs": "^1.11.0",
-        "@parcel/logger": "^1.11.1",
-        "@parcel/utils": "^1.11.0",
-        "@parcel/watcher": "^1.12.1",
-        "@parcel/workers": "^1.11.0",
-        "ansi-to-html": "^0.6.4",
-        "babylon-walk": "^1.0.2",
-        "browserslist": "^4.1.0",
-        "chalk": "^2.1.0",
-        "clone": "^2.1.1",
-        "command-exists": "^1.2.6",
-        "commander": "^2.11.0",
-        "core-js": "^2.6.5",
-        "cross-spawn": "^6.0.4",
-        "css-modules-loader-core": "^1.1.0",
-        "cssnano": "^4.0.0",
-        "deasync": "^0.1.14",
-        "dotenv": "^5.0.0",
-        "dotenv-expand": "^5.1.0",
-        "envinfo": "^7.3.1",
-        "fast-glob": "^2.2.2",
-        "filesize": "^3.6.0",
-        "get-port": "^3.2.0",
-        "htmlnano": "^0.2.2",
-        "is-glob": "^4.0.0",
-        "is-url": "^1.2.2",
-        "js-yaml": "^3.10.0",
-        "json5": "^1.0.1",
-        "micromatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
-        "node-forge": "^0.7.1",
-        "node-libs-browser": "^2.0.0",
-        "opn": "^5.1.0",
-        "postcss": "^7.0.11",
-        "postcss-value-parser": "^3.3.1",
-        "posthtml": "^0.11.2",
-        "posthtml-parser": "^0.4.0",
-        "posthtml-render": "^1.1.3",
-        "resolve": "^1.4.0",
-        "semver": "^5.4.1",
-        "serialize-to-js": "^3.0.0",
-        "serve-static": "^1.12.4",
-        "source-map": "0.6.1",
-        "terser": "^3.7.3",
-        "v8-compile-cache": "^2.0.0",
-        "ws": "^5.1.1"
-      },
-      "dependencies": {
-        "@babel/core": {
-          "version": "7.6.4",
-          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.4.tgz",
-          "integrity": "sha512-Rm0HGw101GY8FTzpWSyRbki/jzq+/PkNQJ+nSulrdY6gFGOsNseCqD6KHRYe2E+EdzuBdr2pxCp6s4Uk6eJ+XQ==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.5.5",
-            "@babel/generator": "^7.6.4",
-            "@babel/helpers": "^7.6.2",
-            "@babel/parser": "^7.6.4",
-            "@babel/template": "^7.6.0",
-            "@babel/traverse": "^7.6.3",
-            "@babel/types": "^7.6.3",
-            "convert-source-map": "^1.1.0",
-            "debug": "^4.1.0",
-            "json5": "^2.1.0",
-            "lodash": "^4.17.13",
-            "resolve": "^1.3.2",
-            "semver": "^5.4.1",
-            "source-map": "^0.5.0"
-          },
-          "dependencies": {
-            "@babel/code-frame": {
-              "version": "7.5.5",
-              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-              "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
-              "dev": true,
-              "requires": {
-                "@babel/highlight": "^7.0.0"
-              }
-            },
-            "json5": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
-              "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
-              "dev": true,
-              "requires": {
-                "minimist": "^1.2.0"
-              }
-            },
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-              "dev": true
-            }
-          }
-        },
-        "@babel/generator": {
-          "version": "7.6.4",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
-          "integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.6.3",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.13",
-            "source-map": "^0.5.0"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-              "dev": true
-            }
-          }
-        },
-        "@babel/helper-call-delegate": {
-          "version": "7.4.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
-          "integrity": "sha512-l79boDFJ8S1c5hvQvG+rc+wHw6IuH7YldmRKsYtpbawsxURu/paVy57FZMomGK22/JckepaikOkY0MoAmdyOlQ==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-hoist-variables": "^7.4.4",
-            "@babel/traverse": "^7.4.4",
-            "@babel/types": "^7.4.4"
-          }
-        },
-        "@babel/helper-define-map": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.5.5.tgz",
-          "integrity": "sha512-fTfxx7i0B5NJqvUOBBGREnrqbTxRh7zinBANpZXAVDlsZxYdclDp467G1sQ8VZYMnAURY3RpBUAgOYT9GfzHBg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/types": "^7.5.5",
-            "lodash": "^4.17.13"
-          }
-        },
-        "@babel/helper-hoist-variables": {
-          "version": "7.4.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz",
-          "integrity": "sha512-VYk2/H/BnYbZDDg39hr3t2kKyifAm1W6zHRfhx8jGjIHpQEBv9dry7oQ2f3+J703TLu69nYdxsovl0XYfcnK4w==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.4.4"
-          }
-        },
-        "@babel/helper-member-expression-to-functions": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz",
-          "integrity": "sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.5.5"
-          }
-        },
-        "@babel/helper-module-transforms": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.5.5.tgz",
-          "integrity": "sha512-jBeCvETKuJqeiaCdyaheF40aXnnU1+wkSiUs/IQg3tB85up1LyL8x77ClY8qJpuRJUcXQo+ZtdNESmZl4j56Pw==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-module-imports": "^7.0.0",
-            "@babel/helper-simple-access": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.4.4",
-            "@babel/template": "^7.4.4",
-            "@babel/types": "^7.5.5",
-            "lodash": "^4.17.13"
-          }
-        },
-        "@babel/helper-regex": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
-          "integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.13"
-          }
-        },
-        "@babel/helper-replace-supers": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz",
-          "integrity": "sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-member-expression-to-functions": "^7.5.5",
-            "@babel/helper-optimise-call-expression": "^7.0.0",
-            "@babel/traverse": "^7.5.5",
-            "@babel/types": "^7.5.5"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.4.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-          "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.4.4"
-          }
-        },
-        "@babel/helpers": {
-          "version": "7.6.2",
-          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.2.tgz",
-          "integrity": "sha512-3/bAUL8zZxYs1cdX2ilEE0WobqbCmKWr/889lf2SS0PpDcpEIY8pb1CCyz0pEcX3pEb+MCbks1jIokz2xLtGTA==",
-          "dev": true,
-          "requires": {
-            "@babel/template": "^7.6.0",
-            "@babel/traverse": "^7.6.2",
-            "@babel/types": "^7.6.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.6.4",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
-          "integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
-          "dev": true
-        },
-        "@babel/plugin-proposal-object-rest-spread": {
-          "version": "7.6.2",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.6.2.tgz",
-          "integrity": "sha512-LDBXlmADCsMZV1Y9OQwMc0MyGZ8Ta/zlD9N67BfQT8uYwkRswiu2hU6nJKrjrt/58aH/vqfQlR/9yId/7A2gWw==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "@babel/plugin-syntax-object-rest-spread": "^7.2.0"
-          }
-        },
-        "@babel/plugin-proposal-unicode-property-regex": {
-          "version": "7.6.2",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.6.2.tgz",
-          "integrity": "sha512-NxHETdmpeSCtiatMRYWVJo7266rrvAC3DTeG5exQBIH/fMIUK7ejDNznBbn3HQl/o9peymRRg7Yqkx6PdUXmMw==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "@babel/helper-regex": "^7.4.4",
-            "regexpu-core": "^4.6.0"
-          }
-        },
-        "@babel/plugin-transform-async-to-generator": {
-          "version": "7.5.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.5.0.tgz",
-          "integrity": "sha512-mqvkzwIGkq0bEF1zLRRiTdjfomZJDV33AH3oQzHVGkI2VzEmXLpKKOBvEVaFZBJdN0XTyH38s9j/Kiqr68dggg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-module-imports": "^7.0.0",
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "@babel/helper-remap-async-to-generator": "^7.1.0"
-          }
-        },
-        "@babel/plugin-transform-block-scoping": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.6.3.tgz",
-          "integrity": "sha512-7hvrg75dubcO3ZI2rjYTzUrEuh1E9IyDEhhB6qfcooxhDA33xx2MasuLVgdxzcP6R/lipAC6n9ub9maNW6RKdw==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "lodash": "^4.17.13"
-          }
-        },
-        "@babel/plugin-transform-classes": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.5.5.tgz",
-          "integrity": "sha512-U2htCNK/6e9K7jGyJ++1p5XRU+LJjrwtoiVn9SzRlDT2KubcZ11OOwy3s24TjHxPgxNwonCYP7U2K51uVYCMDg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-annotate-as-pure": "^7.0.0",
-            "@babel/helper-define-map": "^7.5.5",
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-optimise-call-expression": "^7.0.0",
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "@babel/helper-replace-supers": "^7.5.5",
-            "@babel/helper-split-export-declaration": "^7.4.4",
-            "globals": "^11.1.0"
-          }
-        },
-        "@babel/plugin-transform-destructuring": {
-          "version": "7.6.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.6.0.tgz",
-          "integrity": "sha512-2bGIS5P1v4+sWTCnKNDZDxbGvEqi0ijeqM/YqHtVGrvG2y0ySgnEEhXErvE9dA0bnIzY9bIzdFK0jFA46ASIIQ==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0"
-          }
-        },
-        "@babel/plugin-transform-dotall-regex": {
-          "version": "7.6.2",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.6.2.tgz",
-          "integrity": "sha512-KGKT9aqKV+9YMZSkowzYoYEiHqgaDhGmPNZlZxX6UeHC4z30nC1J9IrZuGqbYFB1jaIGdv91ujpze0exiVK8bA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "@babel/helper-regex": "^7.4.4",
-            "regexpu-core": "^4.6.0"
-          }
-        },
-        "@babel/plugin-transform-duplicate-keys": {
-          "version": "7.5.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.5.0.tgz",
-          "integrity": "sha512-igcziksHizyQPlX9gfSjHkE2wmoCH3evvD2qR5w29/Dk0SMKE/eOI7f1HhBdNhR/zxJDqrgpoDTq5YSLH/XMsQ==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0"
-          }
-        },
-        "@babel/plugin-transform-flow-strip-types": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.6.3.tgz",
-          "integrity": "sha512-l0ETkyEofkqFJ9LS6HChNIKtVJw2ylKbhYMlJ5C6df+ldxxaLIyXY4yOdDQQspfFpV8/vDiaWoJlvflstlYNxg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "@babel/plugin-syntax-flow": "^7.2.0"
-          }
-        },
-        "@babel/plugin-transform-for-of": {
-          "version": "7.4.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz",
-          "integrity": "sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0"
-          }
-        },
-        "@babel/plugin-transform-function-name": {
-          "version": "7.4.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz",
-          "integrity": "sha512-iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-plugin-utils": "^7.0.0"
-          }
-        },
-        "@babel/plugin-transform-modules-amd": {
-          "version": "7.5.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.5.0.tgz",
-          "integrity": "sha512-n20UsQMKnWrltocZZm24cRURxQnWIvsABPJlw/fvoy9c6AgHZzoelAIzajDHAQrDpuKFFPPcFGd7ChsYuIUMpg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-module-transforms": "^7.1.0",
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "babel-plugin-dynamic-import-node": "^2.3.0"
-          }
-        },
-        "@babel/plugin-transform-modules-commonjs": {
-          "version": "7.6.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.6.0.tgz",
-          "integrity": "sha512-Ma93Ix95PNSEngqomy5LSBMAQvYKVe3dy+JlVJSHEXZR5ASL9lQBedMiCyVtmTLraIDVRE3ZjTZvmXXD2Ozw3g==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-module-transforms": "^7.4.4",
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "@babel/helper-simple-access": "^7.1.0",
-            "babel-plugin-dynamic-import-node": "^2.3.0"
-          }
-        },
-        "@babel/plugin-transform-modules-systemjs": {
-          "version": "7.5.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.5.0.tgz",
-          "integrity": "sha512-Q2m56tyoQWmuNGxEtUyeEkm6qJYFqs4c+XyXH5RAuYxObRNz9Zgj/1g2GMnjYp2EUyEy7YTrxliGCXzecl/vJg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-hoist-variables": "^7.4.4",
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "babel-plugin-dynamic-import-node": "^2.3.0"
-          }
-        },
-        "@babel/plugin-transform-named-capturing-groups-regex": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.6.3.tgz",
-          "integrity": "sha512-jTkk7/uE6H2s5w6VlMHeWuH+Pcy2lmdwFoeWCVnvIrDUnB5gQqTVI8WfmEAhF2CDEarGrknZcmSFg1+bkfCoSw==",
-          "dev": true,
-          "requires": {
-            "regexpu-core": "^4.6.0"
-          }
-        },
-        "@babel/plugin-transform-new-target": {
-          "version": "7.4.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz",
-          "integrity": "sha512-r1z3T2DNGQwwe2vPGZMBNjioT2scgWzK9BCnDEh+46z8EEwXBq24uRzd65I7pjtugzPSj921aM15RpESgzsSuA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0"
-          }
-        },
-        "@babel/plugin-transform-object-super": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.5.5.tgz",
-          "integrity": "sha512-un1zJQAhSosGFBduPgN/YFNvWVpRuHKU7IHBglLoLZsGmruJPOo6pbInneflUdmq7YvSVqhpPs5zdBvLnteltQ==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "@babel/helper-replace-supers": "^7.5.5"
-          }
-        },
-        "@babel/plugin-transform-parameters": {
-          "version": "7.4.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz",
-          "integrity": "sha512-oMh5DUO1V63nZcu/ZVLQFqiihBGo4OpxJxR1otF50GMeCLiRx5nUdtokd+u9SuVJrvvuIh9OosRFPP4pIPnwmw==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-call-delegate": "^7.4.4",
-            "@babel/helper-get-function-arity": "^7.0.0",
-            "@babel/helper-plugin-utils": "^7.0.0"
-          }
-        },
-        "@babel/plugin-transform-regenerator": {
-          "version": "7.4.5",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz",
-          "integrity": "sha512-gBKRh5qAaCWntnd09S8QC7r3auLCqq5DI6O0DlfoyDjslSBVqBibrMdsqO+Uhmx3+BlOmE/Kw1HFxmGbv0N9dA==",
-          "dev": true,
-          "requires": {
-            "regenerator-transform": "^0.14.0"
-          }
-        },
-        "@babel/plugin-transform-spread": {
-          "version": "7.6.2",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.6.2.tgz",
-          "integrity": "sha512-DpSvPFryKdK1x+EDJYCy28nmAaIMdxmhot62jAXF/o99iA33Zj2Lmcp3vDmz+MUh0LNYVPvfj5iC3feb3/+PFg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0"
-          }
-        },
-        "@babel/plugin-transform-template-literals": {
-          "version": "7.4.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz",
-          "integrity": "sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-annotate-as-pure": "^7.0.0",
-            "@babel/helper-plugin-utils": "^7.0.0"
-          }
-        },
-        "@babel/plugin-transform-unicode-regex": {
-          "version": "7.6.2",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.6.2.tgz",
-          "integrity": "sha512-orZI6cWlR3nk2YmYdb0gImrgCUwb5cBUwjf6Ks6dvNVvXERkwtJWOQaEOjPiu0Gu1Tq6Yq/hruCZZOOi9F34Dw==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "@babel/helper-regex": "^7.4.4",
-            "regexpu-core": "^4.6.0"
-          }
-        },
-        "@babel/preset-env": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.6.3.tgz",
-          "integrity": "sha512-CWQkn7EVnwzlOdR5NOm2+pfgSNEZmvGjOhlCHBDq0J8/EStr+G+FvPEiz9B56dR6MoiUFjXhfE4hjLoAKKJtIQ==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-module-imports": "^7.0.0",
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
-            "@babel/plugin-proposal-dynamic-import": "^7.5.0",
-            "@babel/plugin-proposal-json-strings": "^7.2.0",
-            "@babel/plugin-proposal-object-rest-spread": "^7.6.2",
-            "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
-            "@babel/plugin-proposal-unicode-property-regex": "^7.6.2",
-            "@babel/plugin-syntax-async-generators": "^7.2.0",
-            "@babel/plugin-syntax-dynamic-import": "^7.2.0",
-            "@babel/plugin-syntax-json-strings": "^7.2.0",
-            "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
-            "@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
-            "@babel/plugin-transform-arrow-functions": "^7.2.0",
-            "@babel/plugin-transform-async-to-generator": "^7.5.0",
-            "@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-            "@babel/plugin-transform-block-scoping": "^7.6.3",
-            "@babel/plugin-transform-classes": "^7.5.5",
-            "@babel/plugin-transform-computed-properties": "^7.2.0",
-            "@babel/plugin-transform-destructuring": "^7.6.0",
-            "@babel/plugin-transform-dotall-regex": "^7.6.2",
-            "@babel/plugin-transform-duplicate-keys": "^7.5.0",
-            "@babel/plugin-transform-exponentiation-operator": "^7.2.0",
-            "@babel/plugin-transform-for-of": "^7.4.4",
-            "@babel/plugin-transform-function-name": "^7.4.4",
-            "@babel/plugin-transform-literals": "^7.2.0",
-            "@babel/plugin-transform-member-expression-literals": "^7.2.0",
-            "@babel/plugin-transform-modules-amd": "^7.5.0",
-            "@babel/plugin-transform-modules-commonjs": "^7.6.0",
-            "@babel/plugin-transform-modules-systemjs": "^7.5.0",
-            "@babel/plugin-transform-modules-umd": "^7.2.0",
-            "@babel/plugin-transform-named-capturing-groups-regex": "^7.6.3",
-            "@babel/plugin-transform-new-target": "^7.4.4",
-            "@babel/plugin-transform-object-super": "^7.5.5",
-            "@babel/plugin-transform-parameters": "^7.4.4",
-            "@babel/plugin-transform-property-literals": "^7.2.0",
-            "@babel/plugin-transform-regenerator": "^7.4.5",
-            "@babel/plugin-transform-reserved-words": "^7.2.0",
-            "@babel/plugin-transform-shorthand-properties": "^7.2.0",
-            "@babel/plugin-transform-spread": "^7.6.2",
-            "@babel/plugin-transform-sticky-regex": "^7.2.0",
-            "@babel/plugin-transform-template-literals": "^7.4.4",
-            "@babel/plugin-transform-typeof-symbol": "^7.2.0",
-            "@babel/plugin-transform-unicode-regex": "^7.6.2",
-            "@babel/types": "^7.6.3",
-            "browserslist": "^4.6.0",
-            "core-js-compat": "^3.1.1",
-            "invariant": "^2.2.2",
-            "js-levenshtein": "^1.1.3",
-            "semver": "^5.5.0"
-          },
-          "dependencies": {
-            "browserslist": {
-              "version": "4.7.2",
-              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.2.tgz",
-              "integrity": "sha512-uZavT/gZXJd2UTi9Ov7/Z340WOSQ3+m1iBVRUknf+okKxonL9P83S3ctiBDtuRmRu8PiCHjqyueqQ9HYlJhxiw==",
-              "dev": true,
-              "requires": {
-                "caniuse-lite": "^1.0.30001004",
-                "electron-to-chromium": "^1.3.295",
-                "node-releases": "^1.1.38"
-              }
-            }
-          }
-        },
-        "@babel/runtime": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
-          "integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
-          "dev": true,
-          "requires": {
-            "regenerator-runtime": "^0.13.2"
-          }
-        },
-        "@babel/template": {
-          "version": "7.6.0",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
-          "integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/parser": "^7.6.0",
-            "@babel/types": "^7.6.0"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.3.tgz",
-          "integrity": "sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.5.5",
-            "@babel/generator": "^7.6.3",
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.4.4",
-            "@babel/parser": "^7.6.3",
-            "@babel/types": "^7.6.3",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.13"
-          },
-          "dependencies": {
-            "@babel/code-frame": {
-              "version": "7.5.5",
-              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-              "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
-              "dev": true,
-              "requires": {
-                "@babel/highlight": "^7.0.0"
-              }
-            }
-          }
-        },
-        "@babel/types": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
-          "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.13",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "@parcel/logger": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-1.11.1.tgz",
-          "integrity": "sha512-9NF3M6UVeP2udOBDILuoEHd8VrF4vQqoWHEafymO1pfSoOMfxrSJZw1MfyAAIUN/IFp9qjcpDCUbDZB+ioVevA==",
-          "dev": true,
-          "requires": {
-            "@parcel/workers": "^1.11.0",
-            "chalk": "^2.1.0",
-            "grapheme-breaker": "^0.3.2",
-            "ora": "^2.1.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "@parcel/watcher": {
-          "version": "1.12.1",
-          "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-1.12.1.tgz",
-          "integrity": "sha512-od+uCtCxC/KoNQAIE1vWx1YTyKYY+7CTrxBJPRh3cDWw/C0tCtlBMVlrbplscGoEpt6B27KhJDCv82PBxOERNA==",
-          "dev": true,
-          "requires": {
-            "@parcel/utils": "^1.11.0",
-            "chokidar": "^2.1.5"
-          }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001008",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001008.tgz",
-          "integrity": "sha512-b8DJyb+VVXZGRgJUa30cbk8gKHZ3LOZTBLaUEEVr2P4xpmFigOCc62CO4uzquW641Ouq1Rm9N+rWLWdSYDaDIw==",
-          "dev": true
-        },
-        "dotenv-expand": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
-          "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
-          "dev": true
-        },
-        "electron-to-chromium": {
-          "version": "1.3.302",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.302.tgz",
-          "integrity": "sha512-1qConyiVEbj4xZRBXqtGR003+9tV0rJF0PS6aeO0Ln/UL637js9hdwweCl07meh/kJoI2N4W8q3R3g3F5z46ww==",
-          "dev": true
-        },
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-          "dev": true
-        },
-        "node-releases": {
-          "version": "1.1.39",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.39.tgz",
-          "integrity": "sha512-8MRC/ErwNCHOlAFycy9OPca46fQYUjbJRDcZTHVWIGXIjYLM73k70vv3WkYutVnM4cCo4hE0MqBVVZjP6vjISA==",
-          "dev": true,
-          "requires": {
-            "semver": "^6.3.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-              "dev": true
-            }
-          }
-        },
-        "regenerate-unicode-properties": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
-          "integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
-          "dev": true,
-          "requires": {
-            "regenerate": "^1.4.0"
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.13.3",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
-          "dev": true
-        },
-        "regenerator-transform": {
-          "version": "0.14.1",
-          "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
-          "integrity": "sha512-flVuee02C3FKRISbxhXl9mGzdbWUVHubl1SMaknjxkFB1/iqpJhArQUvRxOOPEc/9tAiX0BaQ28FJH10E4isSQ==",
-          "dev": true,
-          "requires": {
-            "private": "^0.1.6"
-          }
-        },
-        "regexpu-core": {
-          "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
-          "integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
-          "dev": true,
-          "requires": {
-            "regenerate": "^1.4.0",
-            "regenerate-unicode-properties": "^8.1.0",
-            "regjsgen": "^0.5.0",
-            "regjsparser": "^0.6.0",
-            "unicode-match-property-ecmascript": "^1.0.4",
-            "unicode-match-property-value-ecmascript": "^1.1.0"
-          }
-        },
-        "serialize-to-js": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-3.0.0.tgz",
-          "integrity": "sha512-WdGgi0jGnWCQXph2p3vkxceDnTfvfyXfYxherQMRcZjSaJzMQdMBAW6i0nojsBKIZ3fFOztZKKVbbm05VbIdRA==",
-          "dev": true
-        }
-      }
-    },
     "parcel-bundler": {
-      "version": "npm:parcel@1.12.4",
-      "resolved": "https://registry.npmjs.org/parcel/-/parcel-1.12.4.tgz",
-      "integrity": "sha512-qfc74e2/R4pCoU6L/ZZnK9k3iDS6ir4uHea0e9th9w52eehcAGf2ido/iABq9PBXdsIOe4NSY3oUm7Khe7+S3w==",
+      "version": "1.12.4",
+      "resolved": "https://registry.npmjs.org/parcel-bundler/-/parcel-bundler-1.12.4.tgz",
+      "integrity": "sha512-G+iZGGiPEXcRzw0fiRxWYCKxdt/F7l9a0xkiU4XbcVRJCSlBnioWEwJMutOCCpoQmaQtjB4RBHDGIHN85AIhLQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -6292,12 +6128,12 @@
       },
       "dependencies": {
         "@babel/generator": {
-          "version": "7.6.4",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
-          "integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.0.tgz",
+          "integrity": "sha512-1wdJ6UxHyL1XoJQ119JmvuRX27LRih7iYStMPZOWAjQqeAabFg3dYXKMpgihma+to+0ADsTVVt6oRyUxWZw6Mw==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.6.3",
+            "@babel/types": "^7.7.0",
             "jsesc": "^2.5.1",
             "lodash": "^4.17.13",
             "source-map": "^0.5.0"
@@ -6311,44 +6147,64 @@
             }
           }
         },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.4.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-          "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+        "@babel/helper-function-name": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+          "integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.4.4"
+            "@babel/helper-get-function-arity": "^7.7.0",
+            "@babel/template": "^7.7.0",
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+          "integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.7.0"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
+          "integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.7.0"
           }
         },
         "@babel/parser": {
-          "version": "7.6.4",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
-          "integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.0.tgz",
+          "integrity": "sha512-GqL+Z0d7B7ADlQBMXlJgvXEbtt5qlqd1YQ5fr12hTSfh7O/vgrEIvJxU2e7aSVrEUn75zTZ6Nd0s8tthrlZnrQ==",
           "dev": true
         },
         "@babel/template": {
-          "version": "7.6.0",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
-          "integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+          "integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
-            "@babel/parser": "^7.6.0",
-            "@babel/types": "^7.6.0"
+            "@babel/parser": "^7.7.0",
+            "@babel/types": "^7.7.0"
           }
         },
         "@babel/traverse": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.3.tgz",
-          "integrity": "sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==",
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.0.tgz",
+          "integrity": "sha512-ea/3wRZc//e/uwCpuBX2itrhI0U9l7+FsrKWyKGNyvWbuMcCG7ATKY2VI4wlg2b2TA39HHwIxnvmXvtiKsyn7w==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.5.5",
-            "@babel/generator": "^7.6.3",
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.4.4",
-            "@babel/parser": "^7.6.3",
-            "@babel/types": "^7.6.3",
+            "@babel/generator": "^7.7.0",
+            "@babel/helper-function-name": "^7.7.0",
+            "@babel/helper-split-export-declaration": "^7.7.0",
+            "@babel/parser": "^7.7.0",
+            "@babel/types": "^7.7.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
             "lodash": "^4.17.13"
@@ -6366,9 +6222,9 @@
           }
         },
         "@babel/types": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
-          "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.1.tgz",
+          "integrity": "sha512-kN/XdANDab9x1z5gcjDc9ePpxexkt+1EQ2MQUiM4XnMvQfvp87/+6kY4Ko2maLXH+tei/DgJ/ybFITeqqRwDiA==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,35 +14,116 @@
       }
     },
     "@babel/core": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.3.4.tgz",
-      "integrity": "sha512-jRsuseXBo9pN197KnDwhhaaBzyZr2oIcLHHTt2oDdQrej5Qp57dCCJafWx5ivU8/alEYDpssYqv1MUqcxwQlrA==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.4.tgz",
+      "integrity": "sha512-Rm0HGw101GY8FTzpWSyRbki/jzq+/PkNQJ+nSulrdY6gFGOsNseCqD6KHRYe2E+EdzuBdr2pxCp6s4Uk6eJ+XQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.3.4",
-        "@babel/helpers": "^7.2.0",
-        "@babel/parser": "^7.3.4",
-        "@babel/template": "^7.2.2",
-        "@babel/traverse": "^7.3.4",
-        "@babel/types": "^7.3.4",
+        "@babel/code-frame": "^7.5.5",
+        "@babel/generator": "^7.6.4",
+        "@babel/helpers": "^7.6.2",
+        "@babel/parser": "^7.6.4",
+        "@babel/template": "^7.6.0",
+        "@babel/traverse": "^7.6.3",
+        "@babel/types": "^7.6.3",
         "convert-source-map": "^1.1.0",
         "debug": "^4.1.0",
         "json5": "^2.1.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
       },
       "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+          "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.0.0"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.6.4",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
+          "integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.6.3",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+          "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.4.4"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.6.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
+          "integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
+          "integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/parser": "^7.6.0",
+            "@babel/types": "^7.6.0"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.3.tgz",
+          "integrity": "sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.5.5",
+            "@babel/generator": "^7.6.3",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.4.4",
+            "@babel/parser": "^7.6.3",
+            "@babel/types": "^7.6.3",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/types": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
+          "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
         "json5": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-          "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+          "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
           }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
         },
         "source-map": {
           "version": "0.5.7",
@@ -103,62 +184,85 @@
       }
     },
     "@babel/helper-call-delegate": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.0.tgz",
-      "integrity": "sha512-SdqDfbVdNQCBp3WhK2mNdDvHd3BD6qbmIc43CAyjnsfCmgHMeqgDcM3BzY2lchi7HBJGJ2CVdynLWbezaE4mmQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
+      "integrity": "sha512-l79boDFJ8S1c5hvQvG+rc+wHw6IuH7YldmRKsYtpbawsxURu/paVy57FZMomGK22/JckepaikOkY0MoAmdyOlQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "^7.4.0",
-        "@babel/traverse": "^7.4.0",
-        "@babel/types": "^7.4.0"
+        "@babel/helper-hoist-variables": "^7.4.4",
+        "@babel/traverse": "^7.4.4",
+        "@babel/types": "^7.4.4"
       },
       "dependencies": {
-        "@babel/generator": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
-          "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+        "@babel/code-frame": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+          "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.4.0",
+            "@babel/highlight": "^7.0.0"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.6.4",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
+          "integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.6.3",
             "jsesc": "^2.5.1",
-            "lodash": "^4.17.11",
-            "source-map": "^0.5.0",
-            "trim-right": "^1.0.1"
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+          "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.4.4"
           }
         },
         "@babel/parser": {
-          "version": "7.4.3",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
-          "integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
+          "version": "7.6.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
+          "integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
           "dev": true
         },
         "@babel/traverse": {
-          "version": "7.4.3",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.3.tgz",
-          "integrity": "sha512-HmA01qrtaCwwJWpSKpA948cBvU5BrmviAief/b3AVw936DtcdsTexlbyzNuDnthwhOQ37xshn7hvQaEQk7ISYQ==",
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.3.tgz",
+          "integrity": "sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==",
           "dev": true,
           "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/generator": "^7.4.0",
+            "@babel/code-frame": "^7.5.5",
+            "@babel/generator": "^7.6.3",
             "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.4.0",
-            "@babel/parser": "^7.4.3",
-            "@babel/types": "^7.4.0",
+            "@babel/helper-split-export-declaration": "^7.4.4",
+            "@babel/parser": "^7.6.3",
+            "@babel/types": "^7.6.3",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.11"
+            "lodash": "^4.17.13"
           }
         },
         "@babel/types": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
-          "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
+          "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
-            "lodash": "^4.17.11",
+            "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
         },
         "source-map": {
           "version": "0.5.7",
@@ -169,26 +273,32 @@
       }
     },
     "@babel/helper-define-map": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.4.0.tgz",
-      "integrity": "sha512-wAhQ9HdnLIywERVcSvX40CEJwKdAa1ID4neI9NXQPDOHwwA+57DqwLiPEVy2AIyWzAk0CQ8qx4awO0VUURwLtA==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.5.5.tgz",
+      "integrity": "sha512-fTfxx7i0B5NJqvUOBBGREnrqbTxRh7zinBANpZXAVDlsZxYdclDp467G1sQ8VZYMnAURY3RpBUAgOYT9GfzHBg==",
       "dev": true,
       "requires": {
         "@babel/helper-function-name": "^7.1.0",
-        "@babel/types": "^7.4.0",
-        "lodash": "^4.17.11"
+        "@babel/types": "^7.5.5",
+        "lodash": "^4.17.13"
       },
       "dependencies": {
         "@babel/types": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
-          "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
+          "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
-            "lodash": "^4.17.11",
+            "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
         }
       }
     },
@@ -223,34 +333,59 @@
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.0.tgz",
-      "integrity": "sha512-/NErCuoe/et17IlAQFKWM24qtyYYie7sFIrW/tIQXpck6vAu2hhtYYsKLBWQV+BQZMbcIYPU/QMYuTufrY4aQw==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz",
+      "integrity": "sha512-VYk2/H/BnYbZDDg39hr3t2kKyifAm1W6zHRfhx8jGjIHpQEBv9dry7oQ2f3+J703TLu69nYdxsovl0XYfcnK4w==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.4.0"
+        "@babel/types": "^7.4.4"
       },
       "dependencies": {
         "@babel/types": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
-          "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
+          "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
-            "lodash": "^4.17.11",
+            "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
         }
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
-      "integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz",
+      "integrity": "sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "^7.5.5"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
+          "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "@babel/helper-module-imports": {
@@ -314,63 +449,86 @@
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.4.0.tgz",
-      "integrity": "sha512-PVwCVnWWAgnal+kJ+ZSAphzyl58XrFeSKSAJRiqg5QToTsjL+Xu1f9+RJ+d+Q0aPhPfBGaYfkox66k86thxNSg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz",
+      "integrity": "sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.0.0",
+        "@babel/helper-member-expression-to-functions": "^7.5.5",
         "@babel/helper-optimise-call-expression": "^7.0.0",
-        "@babel/traverse": "^7.4.0",
-        "@babel/types": "^7.4.0"
+        "@babel/traverse": "^7.5.5",
+        "@babel/types": "^7.5.5"
       },
       "dependencies": {
-        "@babel/generator": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
-          "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+        "@babel/code-frame": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+          "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.4.0",
+            "@babel/highlight": "^7.0.0"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.6.4",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
+          "integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.6.3",
             "jsesc": "^2.5.1",
-            "lodash": "^4.17.11",
-            "source-map": "^0.5.0",
-            "trim-right": "^1.0.1"
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+          "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.4.4"
           }
         },
         "@babel/parser": {
-          "version": "7.4.3",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
-          "integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
+          "version": "7.6.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
+          "integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
           "dev": true
         },
         "@babel/traverse": {
-          "version": "7.4.3",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.3.tgz",
-          "integrity": "sha512-HmA01qrtaCwwJWpSKpA948cBvU5BrmviAief/b3AVw936DtcdsTexlbyzNuDnthwhOQ37xshn7hvQaEQk7ISYQ==",
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.3.tgz",
+          "integrity": "sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==",
           "dev": true,
           "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/generator": "^7.4.0",
+            "@babel/code-frame": "^7.5.5",
+            "@babel/generator": "^7.6.3",
             "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.4.0",
-            "@babel/parser": "^7.4.3",
-            "@babel/types": "^7.4.0",
+            "@babel/helper-split-export-declaration": "^7.4.4",
+            "@babel/parser": "^7.6.3",
+            "@babel/types": "^7.6.3",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.11"
+            "lodash": "^4.17.13"
           }
         },
         "@babel/types": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
-          "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
+          "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
-            "lodash": "^4.17.11",
+            "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
         },
         "source-map": {
           "version": "0.5.7",
@@ -425,73 +583,98 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.3.tgz",
-      "integrity": "sha512-BMh7X0oZqb36CfyhvtbSmcWc3GXocfxv3yNsAEuM0l+fAqSO22rQrUpijr3oE/10jCTrB6/0b9kzmG4VetCj8Q==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.2.tgz",
+      "integrity": "sha512-3/bAUL8zZxYs1cdX2ilEE0WobqbCmKWr/889lf2SS0PpDcpEIY8pb1CCyz0pEcX3pEb+MCbks1jIokz2xLtGTA==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.4.0",
-        "@babel/traverse": "^7.4.3",
-        "@babel/types": "^7.4.0"
+        "@babel/template": "^7.6.0",
+        "@babel/traverse": "^7.6.2",
+        "@babel/types": "^7.6.0"
       },
       "dependencies": {
         "@babel/generator": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
-          "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+          "version": "7.6.4",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
+          "integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.4.0",
+            "@babel/types": "^7.6.3",
             "jsesc": "^2.5.1",
-            "lodash": "^4.17.11",
-            "source-map": "^0.5.0",
-            "trim-right": "^1.0.1"
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+          "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.4.4"
           }
         },
         "@babel/parser": {
-          "version": "7.4.3",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
-          "integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
+          "version": "7.6.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
+          "integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
           "dev": true
         },
         "@babel/template": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
-          "integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
+          "integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
-            "@babel/parser": "^7.4.0",
-            "@babel/types": "^7.4.0"
+            "@babel/parser": "^7.6.0",
+            "@babel/types": "^7.6.0"
           }
         },
         "@babel/traverse": {
-          "version": "7.4.3",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.3.tgz",
-          "integrity": "sha512-HmA01qrtaCwwJWpSKpA948cBvU5BrmviAief/b3AVw936DtcdsTexlbyzNuDnthwhOQ37xshn7hvQaEQk7ISYQ==",
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.3.tgz",
+          "integrity": "sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==",
           "dev": true,
           "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/generator": "^7.4.0",
+            "@babel/code-frame": "^7.5.5",
+            "@babel/generator": "^7.6.3",
             "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.4.0",
-            "@babel/parser": "^7.4.3",
-            "@babel/types": "^7.4.0",
+            "@babel/helper-split-export-declaration": "^7.4.4",
+            "@babel/parser": "^7.6.3",
+            "@babel/types": "^7.6.3",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.11"
+            "lodash": "^4.17.13"
+          },
+          "dependencies": {
+            "@babel/code-frame": {
+              "version": "7.5.5",
+              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+              "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+              "dev": true,
+              "requires": {
+                "@babel/highlight": "^7.0.0"
+              }
+            }
           }
         },
         "@babel/types": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
-          "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
+          "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
-            "lodash": "^4.17.11",
+            "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
         },
         "source-map": {
           "version": "0.5.7",
@@ -529,6 +712,16 @@
         "@babel/plugin-syntax-async-generators": "^7.2.0"
       }
     },
+    "@babel/plugin-proposal-dynamic-import": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.5.0.tgz",
+      "integrity": "sha512-x/iMjggsKTFHYC6g11PL7Qy58IK8H5zqfm9e6hu4z1iH2IRyAp9u9dL80zA6R76yFovETFLKz2VJIC2iIPBuFw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.2.0"
+      }
+    },
     "@babel/plugin-proposal-json-strings": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz",
@@ -540,9 +733,9 @@
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.3.tgz",
-      "integrity": "sha512-xC//6DNSSHVjq8O2ge0dyYlhshsH4T7XdCVoxbi5HzLYWfsC5ooFlJjrXk8RcAT+hjHAK9UjBXdylzSoDK3t4g==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.6.2.tgz",
+      "integrity": "sha512-LDBXlmADCsMZV1Y9OQwMc0MyGZ8Ta/zlD9N67BfQT8uYwkRswiu2hU6nJKrjrt/58aH/vqfQlR/9yId/7A2gWw==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -560,20 +753,46 @@
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.0.tgz",
-      "integrity": "sha512-h/KjEZ3nK9wv1P1FSNb9G079jXrNYR0Ko+7XkOx85+gM24iZbPn0rh4vCftk+5QKY7y1uByFataBTmX7irEF1w==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.6.2.tgz",
+      "integrity": "sha512-NxHETdmpeSCtiatMRYWVJo7266rrvAC3DTeG5exQBIH/fMIUK7ejDNznBbn3HQl/o9peymRRg7Yqkx6PdUXmMw==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.0.0",
-        "regexpu-core": "^4.5.4"
+        "@babel/helper-regex": "^7.4.4",
+        "regexpu-core": "^4.6.0"
+      },
+      "dependencies": {
+        "@babel/helper-regex": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
+          "integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.13"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
       "integrity": "sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-dynamic-import": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
+      "integrity": "sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -634,9 +853,9 @@
       }
     },
     "@babel/plugin-transform-async-to-generator": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.0.tgz",
-      "integrity": "sha512-EeaFdCeUULM+GPFEsf7pFcNSxM7hYjoj5fiYbyuiXobW4JhFnjAv9OWzNwHyHcKoPNpAfeRDuW6VyaXEDUBa7g==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.5.0.tgz",
+      "integrity": "sha512-mqvkzwIGkq0bEF1zLRRiTdjfomZJDV33AH3oQzHVGkI2VzEmXLpKKOBvEVaFZBJdN0XTyH38s9j/Kiqr68dggg==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
@@ -654,29 +873,65 @@
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.0.tgz",
-      "integrity": "sha512-AWyt3k+fBXQqt2qb9r97tn3iBwFpiv9xdAiG+Gr2HpAZpuayvbL55yWrsV3MyHvXk/4vmSiedhDRl1YI2Iy5nQ==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.6.3.tgz",
+      "integrity": "sha512-7hvrg75dubcO3ZI2rjYTzUrEuh1E9IyDEhhB6qfcooxhDA33xx2MasuLVgdxzcP6R/lipAC6n9ub9maNW6RKdw==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.13"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.3.tgz",
-      "integrity": "sha512-PUaIKyFUDtG6jF5DUJOfkBdwAS/kFFV3XFk7Nn0a6vR7ZT8jYw5cGtIlat77wcnd0C6ViGqo/wyNf4ZHytF/nQ==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.5.5.tgz",
+      "integrity": "sha512-U2htCNK/6e9K7jGyJ++1p5XRU+LJjrwtoiVn9SzRlDT2KubcZ11OOwy3s24TjHxPgxNwonCYP7U2K51uVYCMDg==",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
-        "@babel/helper-define-map": "^7.4.0",
+        "@babel/helper-define-map": "^7.5.5",
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-optimise-call-expression": "^7.0.0",
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.4.0",
-        "@babel/helper-split-export-declaration": "^7.4.0",
+        "@babel/helper-replace-supers": "^7.5.5",
+        "@babel/helper-split-export-declaration": "^7.4.4",
         "globals": "^11.1.0"
+      },
+      "dependencies": {
+        "@babel/helper-split-export-declaration": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+          "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.4.4"
+          }
+        },
+        "@babel/types": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
+          "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "@babel/plugin-transform-computed-properties": {
@@ -689,29 +944,46 @@
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.3.tgz",
-      "integrity": "sha512-rVTLLZpydDFDyN4qnXdzwoVpk1oaXHIvPEOkOLyr88o7oHxVc/LyrnDx+amuBWGOwUb7D1s/uLsKBNTx08htZg==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.6.0.tgz",
+      "integrity": "sha512-2bGIS5P1v4+sWTCnKNDZDxbGvEqi0ijeqM/YqHtVGrvG2y0ySgnEEhXErvE9dA0bnIzY9bIzdFK0jFA46ASIIQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-dotall-regex": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.3.tgz",
-      "integrity": "sha512-9Arc2I0AGynzXRR/oPdSALv3k0rM38IMFyto7kOCwb5F9sLUt2Ykdo3V9yUPR+Bgr4kb6bVEyLkPEiBhzcTeoA==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.6.2.tgz",
+      "integrity": "sha512-KGKT9aqKV+9YMZSkowzYoYEiHqgaDhGmPNZlZxX6UeHC4z30nC1J9IrZuGqbYFB1jaIGdv91ujpze0exiVK8bA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.4.3",
-        "regexpu-core": "^4.5.4"
+        "@babel/helper-regex": "^7.4.4",
+        "regexpu-core": "^4.6.0"
+      },
+      "dependencies": {
+        "@babel/helper-regex": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
+          "integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.13"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "@babel/plugin-transform-duplicate-keys": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.2.0.tgz",
-      "integrity": "sha512-q+yuxW4DsTjNceUiTzK0L+AfQ0zD9rWaTLiUqHA8p0gxx7lu1EylenfzjeIWNkPy6e/0VG/Wjw9uf9LueQwLOw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.5.0.tgz",
+      "integrity": "sha512-igcziksHizyQPlX9gfSjHkE2wmoCH3evvD2qR5w29/Dk0SMKE/eOI7f1HhBdNhR/zxJDqrgpoDTq5YSLH/XMsQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -728,9 +1000,9 @@
       }
     },
     "@babel/plugin-transform-flow-strip-types": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.3.4.tgz",
-      "integrity": "sha512-PmQC9R7DwpBFA+7ATKMyzViz3zCaMNouzZMPZN2K5PnbBbtL3AXFYTkDk+Hey5crQq2A90UG5Uthz0mel+XZrA==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.6.3.tgz",
+      "integrity": "sha512-l0ETkyEofkqFJ9LS6HChNIKtVJw2ylKbhYMlJ5C6df+ldxxaLIyXY4yOdDQQspfFpV8/vDiaWoJlvflstlYNxg==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -738,18 +1010,18 @@
       }
     },
     "@babel/plugin-transform-for-of": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.3.tgz",
-      "integrity": "sha512-UselcZPwVWNSURnqcfpnxtMehrb8wjXYOimlYQPBnup/Zld426YzIhNEvuRsEWVHfESIECGrxoI6L5QqzuLH5Q==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz",
+      "integrity": "sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-function-name": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.3.tgz",
-      "integrity": "sha512-uT5J/3qI/8vACBR9I1GlAuU/JqBtWdfCrynuOkrWG6nCDieZd5przB1vfP59FRHBZQ9DC2IUfqr/xKqzOD5x0A==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz",
+      "integrity": "sha512-iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==",
       "dev": true,
       "requires": {
         "@babel/helper-function-name": "^7.1.0",
@@ -765,35 +1037,106 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
-    "@babel/plugin-transform-modules-amd": {
+    "@babel/plugin-transform-member-expression-literals": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.2.0.tgz",
-      "integrity": "sha512-mK2A8ucqz1qhrdqjS9VMIDfIvvT2thrEsIQzbaTdc5QFzhDjQv2CkJJ5f6BXIkgbmaoax3zBr2RyvV/8zeoUZw==",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.2.0.tgz",
+      "integrity": "sha512-HiU3zKkSU6scTidmnFJ0bMX8hz5ixC93b4MHMiYebmk2lUVNGOboPsqQvx5LzooihijUoLR/v7Nc1rbBtnc7FA==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.1.0",
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
-    "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.2.0.tgz",
-      "integrity": "sha512-V6y0uaUQrQPXUrmj+hgnks8va2L0zcZymeU7TtWEgdRLNkceafKXEduv7QzgQAE4lT+suwooG9dC7LFhdRAbVQ==",
+    "@babel/plugin-transform-modules-amd": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.5.0.tgz",
+      "integrity": "sha512-n20UsQMKnWrltocZZm24cRURxQnWIvsABPJlw/fvoy9c6AgHZzoelAIzajDHAQrDpuKFFPPcFGd7ChsYuIUMpg==",
       "dev": true,
       "requires": {
         "@babel/helper-module-transforms": "^7.1.0",
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-simple-access": "^7.1.0"
+        "babel-plugin-dynamic-import-node": "^2.3.0"
+      }
+    },
+    "@babel/plugin-transform-modules-commonjs": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.6.0.tgz",
+      "integrity": "sha512-Ma93Ix95PNSEngqomy5LSBMAQvYKVe3dy+JlVJSHEXZR5ASL9lQBedMiCyVtmTLraIDVRE3ZjTZvmXXD2Ozw3g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.4.4",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-simple-access": "^7.1.0",
+        "babel-plugin-dynamic-import-node": "^2.3.0"
+      },
+      "dependencies": {
+        "@babel/helper-module-transforms": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.5.5.tgz",
+          "integrity": "sha512-jBeCvETKuJqeiaCdyaheF40aXnnU1+wkSiUs/IQg3tB85up1LyL8x77ClY8qJpuRJUcXQo+ZtdNESmZl4j56Pw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.0.0",
+            "@babel/helper-simple-access": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.4.4",
+            "@babel/template": "^7.4.4",
+            "@babel/types": "^7.5.5",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+          "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.4.4"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.6.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
+          "integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
+          "integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/parser": "^7.6.0",
+            "@babel/types": "^7.6.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
+          "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.4.0.tgz",
-      "integrity": "sha512-gjPdHmqiNhVoBqus5qK60mWPp1CmYWp/tkh11mvb0rrys01HycEGD7NvvSoKXlWEfSM9TcL36CpsK8ElsADptQ==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.5.0.tgz",
+      "integrity": "sha512-Q2m56tyoQWmuNGxEtUyeEkm6qJYFqs4c+XyXH5RAuYxObRNz9Zgj/1g2GMnjYp2EUyEy7YTrxliGCXzecl/vJg==",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "^7.4.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-hoist-variables": "^7.4.4",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "babel-plugin-dynamic-import-node": "^2.3.0"
       }
     },
     "@babel/plugin-transform-modules-umd": {
@@ -807,41 +1150,50 @@
       }
     },
     "@babel/plugin-transform-named-capturing-groups-regex": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.2.tgz",
-      "integrity": "sha512-NsAuliSwkL3WO2dzWTOL1oZJHm0TM8ZY8ZSxk2ANyKkt5SQlToGA4pzctmq1BEjoacurdwZ3xp2dCQWJkME0gQ==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.6.3.tgz",
+      "integrity": "sha512-jTkk7/uE6H2s5w6VlMHeWuH+Pcy2lmdwFoeWCVnvIrDUnB5gQqTVI8WfmEAhF2CDEarGrknZcmSFg1+bkfCoSw==",
       "dev": true,
       "requires": {
-        "regexp-tree": "^0.1.0"
+        "regexpu-core": "^4.6.0"
       }
     },
     "@babel/plugin-transform-new-target": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.0.tgz",
-      "integrity": "sha512-6ZKNgMQmQmrEX/ncuCwnnw1yVGoaOW5KpxNhoWI7pCQdA0uZ0HqHGqenCUIENAnxRjy2WwNQ30gfGdIgqJXXqw==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz",
+      "integrity": "sha512-r1z3T2DNGQwwe2vPGZMBNjioT2scgWzK9BCnDEh+46z8EEwXBq24uRzd65I7pjtugzPSj921aM15RpESgzsSuA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-object-super": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.2.0.tgz",
-      "integrity": "sha512-VMyhPYZISFZAqAPVkiYb7dUe2AsVi2/wCT5+wZdsNO31FojQJa9ns40hzZ6U9f50Jlq4w6qwzdBB2uwqZ00ebg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.5.5.tgz",
+      "integrity": "sha512-un1zJQAhSosGFBduPgN/YFNvWVpRuHKU7IHBglLoLZsGmruJPOo6pbInneflUdmq7YvSVqhpPs5zdBvLnteltQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.1.0"
+        "@babel/helper-replace-supers": "^7.5.5"
       }
     },
     "@babel/plugin-transform-parameters": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.3.tgz",
-      "integrity": "sha512-ULJYC2Vnw96/zdotCZkMGr2QVfKpIT/4/K+xWWY0MbOJyMZuk660BGkr3bEKWQrrciwz6xpmft39nA4BF7hJuA==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz",
+      "integrity": "sha512-oMh5DUO1V63nZcu/ZVLQFqiihBGo4OpxJxR1otF50GMeCLiRx5nUdtokd+u9SuVJrvvuIh9OosRFPP4pIPnwmw==",
       "dev": true,
       "requires": {
-        "@babel/helper-call-delegate": "^7.4.0",
+        "@babel/helper-call-delegate": "^7.4.4",
         "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-property-literals": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.2.0.tgz",
+      "integrity": "sha512-9q7Dbk4RhgcLp8ebduOpCbtjh7C0itoLYHXd9ueASKAG/is5PQtMR5VJGka9NKqGhYEGn5ITahd4h9QeBMylWQ==",
+      "dev": true,
+      "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
@@ -857,12 +1209,21 @@
       }
     },
     "@babel/plugin-transform-regenerator": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.3.tgz",
-      "integrity": "sha512-kEzotPuOpv6/iSlHroCDydPkKYw7tiJGKlmYp6iJn4a6C/+b2FdttlJsLKYxolYHgotTJ5G5UY5h0qey5ka3+A==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz",
+      "integrity": "sha512-gBKRh5qAaCWntnd09S8QC7r3auLCqq5DI6O0DlfoyDjslSBVqBibrMdsqO+Uhmx3+BlOmE/Kw1HFxmGbv0N9dA==",
       "dev": true,
       "requires": {
-        "regenerator-transform": "^0.13.4"
+        "regenerator-transform": "^0.14.0"
+      }
+    },
+    "@babel/plugin-transform-reserved-words": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.2.0.tgz",
+      "integrity": "sha512-fz43fqW8E1tAB3DKF19/vxbpib1fuyCwSPE418ge5ZxILnBhWyhtPgz8eh1RCGGJlwvksHkyxMxh0eenFi+kFw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
@@ -875,9 +1236,9 @@
       }
     },
     "@babel/plugin-transform-spread": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz",
-      "integrity": "sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.6.2.tgz",
+      "integrity": "sha512-DpSvPFryKdK1x+EDJYCy28nmAaIMdxmhot62jAXF/o99iA33Zj2Lmcp3vDmz+MUh0LNYVPvfj5iC3feb3/+PFg==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -894,9 +1255,9 @@
       }
     },
     "@babel/plugin-transform-template-literals": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.2.0.tgz",
-      "integrity": "sha512-FkPix00J9A/XWXv4VoKJBMeSkyY9x/TqIh76wzcdfl57RJJcf8CehQ08uwfhCDNtRQYtHQKBTwKZDEyjE13Lwg==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz",
+      "integrity": "sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
@@ -913,74 +1274,157 @@
       }
     },
     "@babel/plugin-transform-unicode-regex": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.3.tgz",
-      "integrity": "sha512-lnSNgkVjL8EMtnE8eSS7t2ku8qvKH3eqNf/IwIfnSPUqzgqYmRwzdsQWv4mNQAN9Nuo6Gz1Y0a4CSmdpu1Pp6g==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.6.2.tgz",
+      "integrity": "sha512-orZI6cWlR3nk2YmYdb0gImrgCUwb5cBUwjf6Ks6dvNVvXERkwtJWOQaEOjPiu0Gu1Tq6Yq/hruCZZOOi9F34Dw==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.4.3",
-        "regexpu-core": "^4.5.4"
+        "@babel/helper-regex": "^7.4.4",
+        "regexpu-core": "^4.6.0"
+      },
+      "dependencies": {
+        "@babel/helper-regex": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
+          "integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.13"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "@babel/preset-env": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.3.4.tgz",
-      "integrity": "sha512-2mwqfYMK8weA0g0uBKOt4FE3iEodiHy9/CW0b+nWXcbL+pGzLx8ESYc+j9IIxr6LTDHWKgPm71i9smo02bw+gA==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.6.3.tgz",
+      "integrity": "sha512-CWQkn7EVnwzlOdR5NOm2+pfgSNEZmvGjOhlCHBDq0J8/EStr+G+FvPEiz9B56dR6MoiUFjXhfE4hjLoAKKJtIQ==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
+        "@babel/plugin-proposal-dynamic-import": "^7.5.0",
         "@babel/plugin-proposal-json-strings": "^7.2.0",
-        "@babel/plugin-proposal-object-rest-spread": "^7.3.4",
+        "@babel/plugin-proposal-object-rest-spread": "^7.6.2",
         "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
-        "@babel/plugin-proposal-unicode-property-regex": "^7.2.0",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.6.2",
         "@babel/plugin-syntax-async-generators": "^7.2.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.2.0",
         "@babel/plugin-syntax-json-strings": "^7.2.0",
         "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
         "@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
         "@babel/plugin-transform-arrow-functions": "^7.2.0",
-        "@babel/plugin-transform-async-to-generator": "^7.3.4",
+        "@babel/plugin-transform-async-to-generator": "^7.5.0",
         "@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-        "@babel/plugin-transform-block-scoping": "^7.3.4",
-        "@babel/plugin-transform-classes": "^7.3.4",
+        "@babel/plugin-transform-block-scoping": "^7.6.3",
+        "@babel/plugin-transform-classes": "^7.5.5",
         "@babel/plugin-transform-computed-properties": "^7.2.0",
-        "@babel/plugin-transform-destructuring": "^7.2.0",
-        "@babel/plugin-transform-dotall-regex": "^7.2.0",
-        "@babel/plugin-transform-duplicate-keys": "^7.2.0",
+        "@babel/plugin-transform-destructuring": "^7.6.0",
+        "@babel/plugin-transform-dotall-regex": "^7.6.2",
+        "@babel/plugin-transform-duplicate-keys": "^7.5.0",
         "@babel/plugin-transform-exponentiation-operator": "^7.2.0",
-        "@babel/plugin-transform-for-of": "^7.2.0",
-        "@babel/plugin-transform-function-name": "^7.2.0",
+        "@babel/plugin-transform-for-of": "^7.4.4",
+        "@babel/plugin-transform-function-name": "^7.4.4",
         "@babel/plugin-transform-literals": "^7.2.0",
-        "@babel/plugin-transform-modules-amd": "^7.2.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.2.0",
-        "@babel/plugin-transform-modules-systemjs": "^7.3.4",
+        "@babel/plugin-transform-member-expression-literals": "^7.2.0",
+        "@babel/plugin-transform-modules-amd": "^7.5.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.6.0",
+        "@babel/plugin-transform-modules-systemjs": "^7.5.0",
         "@babel/plugin-transform-modules-umd": "^7.2.0",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.3.0",
-        "@babel/plugin-transform-new-target": "^7.0.0",
-        "@babel/plugin-transform-object-super": "^7.2.0",
-        "@babel/plugin-transform-parameters": "^7.2.0",
-        "@babel/plugin-transform-regenerator": "^7.3.4",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.6.3",
+        "@babel/plugin-transform-new-target": "^7.4.4",
+        "@babel/plugin-transform-object-super": "^7.5.5",
+        "@babel/plugin-transform-parameters": "^7.4.4",
+        "@babel/plugin-transform-property-literals": "^7.2.0",
+        "@babel/plugin-transform-regenerator": "^7.4.5",
+        "@babel/plugin-transform-reserved-words": "^7.2.0",
         "@babel/plugin-transform-shorthand-properties": "^7.2.0",
-        "@babel/plugin-transform-spread": "^7.2.0",
+        "@babel/plugin-transform-spread": "^7.6.2",
         "@babel/plugin-transform-sticky-regex": "^7.2.0",
-        "@babel/plugin-transform-template-literals": "^7.2.0",
+        "@babel/plugin-transform-template-literals": "^7.4.4",
         "@babel/plugin-transform-typeof-symbol": "^7.2.0",
-        "@babel/plugin-transform-unicode-regex": "^7.2.0",
-        "browserslist": "^4.3.4",
+        "@babel/plugin-transform-unicode-regex": "^7.6.2",
+        "@babel/types": "^7.6.3",
+        "browserslist": "^4.6.0",
+        "core-js-compat": "^3.1.1",
         "invariant": "^2.2.2",
         "js-levenshtein": "^1.1.3",
-        "semver": "^5.3.0"
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
+          "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "browserslist": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.2.tgz",
+          "integrity": "sha512-uZavT/gZXJd2UTi9Ov7/Z340WOSQ3+m1iBVRUknf+okKxonL9P83S3ctiBDtuRmRu8PiCHjqyueqQ9HYlJhxiw==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30001004",
+            "electron-to-chromium": "^1.3.295",
+            "node-releases": "^1.1.38"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001008",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001008.tgz",
+          "integrity": "sha512-b8DJyb+VVXZGRgJUa30cbk8gKHZ3LOZTBLaUEEVr2P4xpmFigOCc62CO4uzquW641Ouq1Rm9N+rWLWdSYDaDIw==",
+          "dev": true
+        },
+        "electron-to-chromium": {
+          "version": "1.3.302",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.302.tgz",
+          "integrity": "sha512-1qConyiVEbj4xZRBXqtGR003+9tV0rJF0PS6aeO0Ln/UL637js9hdwweCl07meh/kJoI2N4W8q3R3g3F5z46ww==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
+        "node-releases": {
+          "version": "1.1.39",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.39.tgz",
+          "integrity": "sha512-8MRC/ErwNCHOlAFycy9OPca46fQYUjbJRDcZTHVWIGXIjYLM73k70vv3WkYutVnM4cCo4hE0MqBVVZjP6vjISA==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.3.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+              "dev": true
+            }
+          }
+        }
       }
     },
     "@babel/runtime": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.4.tgz",
-      "integrity": "sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
+      "integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
       "dev": true,
       "requires": {
-        "regenerator-runtime": "^0.12.0"
+        "regenerator-runtime": "^0.13.2"
       }
     },
     "@babel/template": {
@@ -1056,9 +1500,9 @@
       }
     },
     "@parcel/logger": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-1.11.0.tgz",
-      "integrity": "sha512-lIRfDg+junbFUUeU0QtHX00gKCgEsYHZydFKwrJ8dc0D+WE2SYT1FcVCgpPAfKYgtg0QQMns8E9vzT9UjH92PQ==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-1.11.1.tgz",
+      "integrity": "sha512-9NF3M6UVeP2udOBDILuoEHd8VrF4vQqoWHEafymO1pfSoOMfxrSJZw1MfyAAIUN/IFp9qjcpDCUbDZB+ioVevA==",
       "dev": true,
       "requires": {
         "@parcel/workers": "^1.11.0",
@@ -1075,13 +1519,13 @@
       "dev": true
     },
     "@parcel/watcher": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-1.12.0.tgz",
-      "integrity": "sha512-yijGiAqG7Tjf5WnFwOkiNWwerfZQDNABldiiqRDtr7vDWLO+F/DIncyB7tTcaD5Loevrr5mzzGo8Ntf3d2GIPg==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-1.12.1.tgz",
+      "integrity": "sha512-od+uCtCxC/KoNQAIE1vWx1YTyKYY+7CTrxBJPRh3cDWw/C0tCtlBMVlrbplscGoEpt6B27KhJDCv82PBxOERNA==",
       "dev": true,
       "requires": {
         "@parcel/utils": "^1.11.0",
-        "chokidar": "^2.0.3"
+        "chokidar": "^2.1.5"
       }
     },
     "@parcel/workers": {
@@ -1104,12 +1548,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
       "integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
-      "dev": true
-    },
-    "abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
     "acorn": {
@@ -1337,6 +1775,15 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
+    },
+    "babel-plugin-dynamic-import-node": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
+      "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
+      "dev": true,
+      "requires": {
+        "object.assign": "^4.1.0"
+      }
     },
     "babel-runtime": {
       "version": "6.26.0",
@@ -1837,12 +2284,6 @@
       "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
       "dev": true
     },
-    "clones": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/clones/-/clones-1.2.0.tgz",
-      "integrity": "sha512-FXDYw4TjR8wgPZYui2LeTqWh1BLpfQ8lB6upMtlpDF6WlOOxghmTTxWyngdKTgozqBgKnHbTVwTE+hOHqAykuQ==",
-      "dev": true
-    },
     "coa": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
@@ -1944,16 +2385,6 @@
         "typedarray": "^0.0.6"
       }
     },
-    "config-chain": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
-      "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
-      "dev": true,
-      "requires": {
-        "ini": "^1.3.4",
-        "proto-list": "~1.2.1"
-      }
-    },
     "console-browserify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
@@ -1989,6 +2420,56 @@
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
       "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
       "dev": true
+    },
+    "core-js-compat": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.3.6.tgz",
+      "integrity": "sha512-YnwZG/+0/f7Pf6Lr3jxtVAFjtGBW9lsLYcqrxhYJai1GfvrP8DEyEpnNzj/FRQfIkOOfk1j5tTBvPBLWVVJm4A==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.7.2",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.2.tgz",
+          "integrity": "sha512-uZavT/gZXJd2UTi9Ov7/Z340WOSQ3+m1iBVRUknf+okKxonL9P83S3ctiBDtuRmRu8PiCHjqyueqQ9HYlJhxiw==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30001004",
+            "electron-to-chromium": "^1.3.295",
+            "node-releases": "^1.1.38"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001008",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001008.tgz",
+          "integrity": "sha512-b8DJyb+VVXZGRgJUa30cbk8gKHZ3LOZTBLaUEEVr2P4xpmFigOCc62CO4uzquW641Ouq1Rm9N+rWLWdSYDaDIw==",
+          "dev": true
+        },
+        "electron-to-chromium": {
+          "version": "1.3.302",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.302.tgz",
+          "integrity": "sha512-1qConyiVEbj4xZRBXqtGR003+9tV0rJF0PS6aeO0Ln/UL637js9hdwweCl07meh/kJoI2N4W8q3R3g3F5z46ww==",
+          "dev": true
+        },
+        "node-releases": {
+          "version": "1.1.39",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.39.tgz",
+          "integrity": "sha512-8MRC/ErwNCHOlAFycy9OPca46fQYUjbJRDcZTHVWIGXIjYLM73k70vv3WkYutVnM4cCo4hE0MqBVVZjP6vjISA==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.3.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -2655,9 +3136,9 @@
       "dev": true
     },
     "dotenv-expand": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-4.2.0.tgz",
-      "integrity": "sha1-3vHxyl1gWdJKdm5YeULCEQbOEnU=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
+      "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
       "dev": true
     },
     "duplexer2": {
@@ -2677,18 +3158,6 @@
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
-      }
-    },
-    "editorconfig": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
-      "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
-      "dev": true,
-      "requires": {
-        "commander": "^2.19.0",
-        "lru-cache": "^4.1.5",
-        "semver": "^5.6.0",
-        "sigmund": "^1.0.1"
       }
     },
     "ee-first": {
@@ -2734,6 +3203,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
       "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+      "dev": true
+    },
+    "envinfo": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.4.0.tgz",
+      "integrity": "sha512-FdDfnWnCVjxTTpWE3d6Jgh5JDIA3Cw7LCgpM/pI7kK1ORkjaqI2r6NqQ+ln2j0dfpgxY00AWieSvtkiZQKIItA==",
       "dev": true
     },
     "error-ex": {
@@ -3121,14 +3596,14 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
-      "integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
+        "nan": "^2.12.1",
+        "node-pre-gyp": "^0.12.0"
       },
       "dependencies": {
         "abbrev": {
@@ -3206,12 +3681,12 @@
           "optional": true
         },
         "debug": {
-          "version": "2.6.9",
+          "version": "4.1.1",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
         },
         "deep-extend": {
@@ -3382,24 +3857,24 @@
           }
         },
         "ms": {
-          "version": "2.0.0",
+          "version": "2.1.1",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "needle": {
-          "version": "2.2.4",
+          "version": "2.3.0",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^2.1.2",
+            "debug": "^4.1.0",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
-          "version": "0.10.3",
+          "version": "0.12.0",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -3427,13 +3902,13 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.5",
+          "version": "1.0.6",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.2.0",
+          "version": "1.4.1",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -3572,7 +4047,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.6.0",
+          "version": "5.7.0",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -4054,12 +4529,6 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
-    "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-      "dev": true
-    },
     "invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -4333,19 +4802,6 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
-    "js-beautify": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.9.1.tgz",
-      "integrity": "sha512-oxxvVZdOdUfzk8IOLBF2XUZvl2GoBEfA+b0of4u2EBY/46NlXasi8JdFvazA5lCrf9/lQhTjyVy2QCUW7iq0MQ==",
-      "dev": true,
-      "requires": {
-        "config-chain": "^1.1.12",
-        "editorconfig": "^0.15.2",
-        "glob": "^7.1.3",
-        "mkdirp": "~0.5.0",
-        "nopt": "~4.0.1"
-      }
-    },
     "js-levenshtein": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
@@ -4563,16 +5019,6 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
-    "lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "dev": true,
-      "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
-    },
     "magic-string": {
       "version": "0.22.5",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
@@ -4767,9 +5213,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "dev": true,
       "optional": true
     },
@@ -4856,16 +5302,6 @@
       "dev": true,
       "requires": {
         "semver": "^5.3.0"
-      }
-    },
-    "nopt": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-      "dev": true,
-      "requires": {
-        "abbrev": "1",
-        "osenv": "^0.1.4"
       }
     },
     "normalize-html-whitespace": {
@@ -4963,6 +5399,18 @@
       "dev": true,
       "requires": {
         "isobject": "^3.0.0"
+      }
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
       }
     },
     "object.getownpropertydescriptors": {
@@ -5066,57 +5514,35 @@
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
       "dev": true
     },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
-    },
-    "osenv": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-      "dev": true,
-      "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
-      }
-    },
     "pako": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
       "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
       "dev": true
     },
-    "parcel-bundler": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/parcel-bundler/-/parcel-bundler-1.12.3.tgz",
-      "integrity": "sha512-8bq6lj0hhQeGxD9f9xEkFMXQ3d8TIlf2+isKxoi9bciB0KVEILRGllaPkUgp++5t0anToBh9+tG6ZyInXOC1/A==",
+    "parcel": {
+      "version": "1.12.4",
+      "resolved": "https://registry.npmjs.org/parcel/-/parcel-1.12.4.tgz",
+      "integrity": "sha512-qfc74e2/R4pCoU6L/ZZnK9k3iDS6ir4uHea0e9th9w52eehcAGf2ido/iABq9PBXdsIOe4NSY3oUm7Khe7+S3w==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0 <7.4.0",
-        "@babel/core": "^7.0.0 <7.4.0",
-        "@babel/generator": "^7.0.0 <7.4.0",
-        "@babel/parser": "^7.0.0 <7.4.0",
-        "@babel/plugin-transform-flow-strip-types": "^7.0.0 <7.4.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.0.0 <7.4.0",
-        "@babel/plugin-transform-react-jsx": "^7.0.0 <7.4.0",
-        "@babel/preset-env": "^7.0.0 <7.4.0",
-        "@babel/runtime": "^7.0.0 <7.4.0",
-        "@babel/template": "^7.0.0 <7.4.0",
-        "@babel/traverse": "^7.0.0 <7.4.0",
-        "@babel/types": "^7.0.0 <7.4.0",
+        "@babel/code-frame": "^7.0.0",
+        "@babel/core": "^7.4.4",
+        "@babel/generator": "^7.4.4",
+        "@babel/parser": "^7.4.4",
+        "@babel/plugin-transform-flow-strip-types": "^7.4.4",
+        "@babel/plugin-transform-modules-commonjs": "^7.4.4",
+        "@babel/plugin-transform-react-jsx": "^7.0.0",
+        "@babel/preset-env": "^7.4.4",
+        "@babel/runtime": "^7.4.4",
+        "@babel/template": "^7.4.4",
+        "@babel/traverse": "^7.4.4",
+        "@babel/types": "^7.4.4",
         "@iarna/toml": "^2.2.0",
         "@parcel/fs": "^1.11.0",
-        "@parcel/logger": "^1.11.0",
+        "@parcel/logger": "^1.11.1",
         "@parcel/utils": "^1.11.0",
-        "@parcel/watcher": "^1.12.0",
+        "@parcel/watcher": "^1.12.1",
         "@parcel/workers": "^1.11.0",
         "ansi-to-html": "^0.6.4",
         "babylon-walk": "^1.0.2",
@@ -5125,12 +5551,14 @@
         "clone": "^2.1.1",
         "command-exists": "^1.2.6",
         "commander": "^2.11.0",
+        "core-js": "^2.6.5",
         "cross-spawn": "^6.0.4",
         "css-modules-loader-core": "^1.1.0",
         "cssnano": "^4.0.0",
         "deasync": "^0.1.14",
         "dotenv": "^5.0.0",
-        "dotenv-expand": "^4.2.0",
+        "dotenv-expand": "^5.1.0",
+        "envinfo": "^7.3.1",
         "fast-glob": "^2.2.2",
         "filesize": "^3.6.0",
         "get-port": "^3.2.0",
@@ -5151,12 +5579,809 @@
         "posthtml-render": "^1.1.3",
         "resolve": "^1.4.0",
         "semver": "^5.4.1",
-        "serialize-to-js": "^1.1.1",
+        "serialize-to-js": "^3.0.0",
         "serve-static": "^1.12.4",
         "source-map": "0.6.1",
         "terser": "^3.7.3",
         "v8-compile-cache": "^2.0.0",
         "ws": "^5.1.1"
+      },
+      "dependencies": {
+        "@babel/core": {
+          "version": "7.6.4",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.4.tgz",
+          "integrity": "sha512-Rm0HGw101GY8FTzpWSyRbki/jzq+/PkNQJ+nSulrdY6gFGOsNseCqD6KHRYe2E+EdzuBdr2pxCp6s4Uk6eJ+XQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.5.5",
+            "@babel/generator": "^7.6.4",
+            "@babel/helpers": "^7.6.2",
+            "@babel/parser": "^7.6.4",
+            "@babel/template": "^7.6.0",
+            "@babel/traverse": "^7.6.3",
+            "@babel/types": "^7.6.3",
+            "convert-source-map": "^1.1.0",
+            "debug": "^4.1.0",
+            "json5": "^2.1.0",
+            "lodash": "^4.17.13",
+            "resolve": "^1.3.2",
+            "semver": "^5.4.1",
+            "source-map": "^0.5.0"
+          },
+          "dependencies": {
+            "@babel/code-frame": {
+              "version": "7.5.5",
+              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+              "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+              "dev": true,
+              "requires": {
+                "@babel/highlight": "^7.0.0"
+              }
+            },
+            "json5": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+              "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
+              "dev": true,
+              "requires": {
+                "minimist": "^1.2.0"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "dev": true
+            }
+          }
+        },
+        "@babel/generator": {
+          "version": "7.6.4",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
+          "integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.6.3",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "dev": true
+            }
+          }
+        },
+        "@babel/helper-call-delegate": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
+          "integrity": "sha512-l79boDFJ8S1c5hvQvG+rc+wHw6IuH7YldmRKsYtpbawsxURu/paVy57FZMomGK22/JckepaikOkY0MoAmdyOlQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-hoist-variables": "^7.4.4",
+            "@babel/traverse": "^7.4.4",
+            "@babel/types": "^7.4.4"
+          }
+        },
+        "@babel/helper-define-map": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.5.5.tgz",
+          "integrity": "sha512-fTfxx7i0B5NJqvUOBBGREnrqbTxRh7zinBANpZXAVDlsZxYdclDp467G1sQ8VZYMnAURY3RpBUAgOYT9GfzHBg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/types": "^7.5.5",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/helper-hoist-variables": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz",
+          "integrity": "sha512-VYk2/H/BnYbZDDg39hr3t2kKyifAm1W6zHRfhx8jGjIHpQEBv9dry7oQ2f3+J703TLu69nYdxsovl0XYfcnK4w==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.4.4"
+          }
+        },
+        "@babel/helper-member-expression-to-functions": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz",
+          "integrity": "sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.5.5"
+          }
+        },
+        "@babel/helper-module-transforms": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.5.5.tgz",
+          "integrity": "sha512-jBeCvETKuJqeiaCdyaheF40aXnnU1+wkSiUs/IQg3tB85up1LyL8x77ClY8qJpuRJUcXQo+ZtdNESmZl4j56Pw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.0.0",
+            "@babel/helper-simple-access": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.4.4",
+            "@babel/template": "^7.4.4",
+            "@babel/types": "^7.5.5",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/helper-regex": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
+          "integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/helper-replace-supers": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz",
+          "integrity": "sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-member-expression-to-functions": "^7.5.5",
+            "@babel/helper-optimise-call-expression": "^7.0.0",
+            "@babel/traverse": "^7.5.5",
+            "@babel/types": "^7.5.5"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+          "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.4.4"
+          }
+        },
+        "@babel/helpers": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.2.tgz",
+          "integrity": "sha512-3/bAUL8zZxYs1cdX2ilEE0WobqbCmKWr/889lf2SS0PpDcpEIY8pb1CCyz0pEcX3pEb+MCbks1jIokz2xLtGTA==",
+          "dev": true,
+          "requires": {
+            "@babel/template": "^7.6.0",
+            "@babel/traverse": "^7.6.2",
+            "@babel/types": "^7.6.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.6.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
+          "integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
+          "dev": true
+        },
+        "@babel/plugin-proposal-object-rest-spread": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.6.2.tgz",
+          "integrity": "sha512-LDBXlmADCsMZV1Y9OQwMc0MyGZ8Ta/zlD9N67BfQT8uYwkRswiu2hU6nJKrjrt/58aH/vqfQlR/9yId/7A2gWw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-object-rest-spread": "^7.2.0"
+          }
+        },
+        "@babel/plugin-proposal-unicode-property-regex": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.6.2.tgz",
+          "integrity": "sha512-NxHETdmpeSCtiatMRYWVJo7266rrvAC3DTeG5exQBIH/fMIUK7ejDNznBbn3HQl/o9peymRRg7Yqkx6PdUXmMw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-regex": "^7.4.4",
+            "regexpu-core": "^4.6.0"
+          }
+        },
+        "@babel/plugin-transform-async-to-generator": {
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.5.0.tgz",
+          "integrity": "sha512-mqvkzwIGkq0bEF1zLRRiTdjfomZJDV33AH3oQzHVGkI2VzEmXLpKKOBvEVaFZBJdN0XTyH38s9j/Kiqr68dggg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-remap-async-to-generator": "^7.1.0"
+          }
+        },
+        "@babel/plugin-transform-block-scoping": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.6.3.tgz",
+          "integrity": "sha512-7hvrg75dubcO3ZI2rjYTzUrEuh1E9IyDEhhB6qfcooxhDA33xx2MasuLVgdxzcP6R/lipAC6n9ub9maNW6RKdw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/plugin-transform-classes": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.5.5.tgz",
+          "integrity": "sha512-U2htCNK/6e9K7jGyJ++1p5XRU+LJjrwtoiVn9SzRlDT2KubcZ11OOwy3s24TjHxPgxNwonCYP7U2K51uVYCMDg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.0.0",
+            "@babel/helper-define-map": "^7.5.5",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-optimise-call-expression": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-replace-supers": "^7.5.5",
+            "@babel/helper-split-export-declaration": "^7.4.4",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/plugin-transform-destructuring": {
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.6.0.tgz",
+          "integrity": "sha512-2bGIS5P1v4+sWTCnKNDZDxbGvEqi0ijeqM/YqHtVGrvG2y0ySgnEEhXErvE9dA0bnIzY9bIzdFK0jFA46ASIIQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-dotall-regex": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.6.2.tgz",
+          "integrity": "sha512-KGKT9aqKV+9YMZSkowzYoYEiHqgaDhGmPNZlZxX6UeHC4z30nC1J9IrZuGqbYFB1jaIGdv91ujpze0exiVK8bA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-regex": "^7.4.4",
+            "regexpu-core": "^4.6.0"
+          }
+        },
+        "@babel/plugin-transform-duplicate-keys": {
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.5.0.tgz",
+          "integrity": "sha512-igcziksHizyQPlX9gfSjHkE2wmoCH3evvD2qR5w29/Dk0SMKE/eOI7f1HhBdNhR/zxJDqrgpoDTq5YSLH/XMsQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-flow-strip-types": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.6.3.tgz",
+          "integrity": "sha512-l0ETkyEofkqFJ9LS6HChNIKtVJw2ylKbhYMlJ5C6df+ldxxaLIyXY4yOdDQQspfFpV8/vDiaWoJlvflstlYNxg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-flow": "^7.2.0"
+          }
+        },
+        "@babel/plugin-transform-for-of": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz",
+          "integrity": "sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-function-name": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz",
+          "integrity": "sha512-iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-modules-amd": {
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.5.0.tgz",
+          "integrity": "sha512-n20UsQMKnWrltocZZm24cRURxQnWIvsABPJlw/fvoy9c6AgHZzoelAIzajDHAQrDpuKFFPPcFGd7ChsYuIUMpg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-transforms": "^7.1.0",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "babel-plugin-dynamic-import-node": "^2.3.0"
+          }
+        },
+        "@babel/plugin-transform-modules-commonjs": {
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.6.0.tgz",
+          "integrity": "sha512-Ma93Ix95PNSEngqomy5LSBMAQvYKVe3dy+JlVJSHEXZR5ASL9lQBedMiCyVtmTLraIDVRE3ZjTZvmXXD2Ozw3g==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-transforms": "^7.4.4",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-simple-access": "^7.1.0",
+            "babel-plugin-dynamic-import-node": "^2.3.0"
+          }
+        },
+        "@babel/plugin-transform-modules-systemjs": {
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.5.0.tgz",
+          "integrity": "sha512-Q2m56tyoQWmuNGxEtUyeEkm6qJYFqs4c+XyXH5RAuYxObRNz9Zgj/1g2GMnjYp2EUyEy7YTrxliGCXzecl/vJg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-hoist-variables": "^7.4.4",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "babel-plugin-dynamic-import-node": "^2.3.0"
+          }
+        },
+        "@babel/plugin-transform-named-capturing-groups-regex": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.6.3.tgz",
+          "integrity": "sha512-jTkk7/uE6H2s5w6VlMHeWuH+Pcy2lmdwFoeWCVnvIrDUnB5gQqTVI8WfmEAhF2CDEarGrknZcmSFg1+bkfCoSw==",
+          "dev": true,
+          "requires": {
+            "regexpu-core": "^4.6.0"
+          }
+        },
+        "@babel/plugin-transform-new-target": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz",
+          "integrity": "sha512-r1z3T2DNGQwwe2vPGZMBNjioT2scgWzK9BCnDEh+46z8EEwXBq24uRzd65I7pjtugzPSj921aM15RpESgzsSuA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-object-super": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.5.5.tgz",
+          "integrity": "sha512-un1zJQAhSosGFBduPgN/YFNvWVpRuHKU7IHBglLoLZsGmruJPOo6pbInneflUdmq7YvSVqhpPs5zdBvLnteltQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-replace-supers": "^7.5.5"
+          }
+        },
+        "@babel/plugin-transform-parameters": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz",
+          "integrity": "sha512-oMh5DUO1V63nZcu/ZVLQFqiihBGo4OpxJxR1otF50GMeCLiRx5nUdtokd+u9SuVJrvvuIh9OosRFPP4pIPnwmw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-call-delegate": "^7.4.4",
+            "@babel/helper-get-function-arity": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-regenerator": {
+          "version": "7.4.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz",
+          "integrity": "sha512-gBKRh5qAaCWntnd09S8QC7r3auLCqq5DI6O0DlfoyDjslSBVqBibrMdsqO+Uhmx3+BlOmE/Kw1HFxmGbv0N9dA==",
+          "dev": true,
+          "requires": {
+            "regenerator-transform": "^0.14.0"
+          }
+        },
+        "@babel/plugin-transform-spread": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.6.2.tgz",
+          "integrity": "sha512-DpSvPFryKdK1x+EDJYCy28nmAaIMdxmhot62jAXF/o99iA33Zj2Lmcp3vDmz+MUh0LNYVPvfj5iC3feb3/+PFg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-template-literals": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz",
+          "integrity": "sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-unicode-regex": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.6.2.tgz",
+          "integrity": "sha512-orZI6cWlR3nk2YmYdb0gImrgCUwb5cBUwjf6Ks6dvNVvXERkwtJWOQaEOjPiu0Gu1Tq6Yq/hruCZZOOi9F34Dw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-regex": "^7.4.4",
+            "regexpu-core": "^4.6.0"
+          }
+        },
+        "@babel/preset-env": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.6.3.tgz",
+          "integrity": "sha512-CWQkn7EVnwzlOdR5NOm2+pfgSNEZmvGjOhlCHBDq0J8/EStr+G+FvPEiz9B56dR6MoiUFjXhfE4hjLoAKKJtIQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
+            "@babel/plugin-proposal-dynamic-import": "^7.5.0",
+            "@babel/plugin-proposal-json-strings": "^7.2.0",
+            "@babel/plugin-proposal-object-rest-spread": "^7.6.2",
+            "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
+            "@babel/plugin-proposal-unicode-property-regex": "^7.6.2",
+            "@babel/plugin-syntax-async-generators": "^7.2.0",
+            "@babel/plugin-syntax-dynamic-import": "^7.2.0",
+            "@babel/plugin-syntax-json-strings": "^7.2.0",
+            "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
+            "@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
+            "@babel/plugin-transform-arrow-functions": "^7.2.0",
+            "@babel/plugin-transform-async-to-generator": "^7.5.0",
+            "@babel/plugin-transform-block-scoped-functions": "^7.2.0",
+            "@babel/plugin-transform-block-scoping": "^7.6.3",
+            "@babel/plugin-transform-classes": "^7.5.5",
+            "@babel/plugin-transform-computed-properties": "^7.2.0",
+            "@babel/plugin-transform-destructuring": "^7.6.0",
+            "@babel/plugin-transform-dotall-regex": "^7.6.2",
+            "@babel/plugin-transform-duplicate-keys": "^7.5.0",
+            "@babel/plugin-transform-exponentiation-operator": "^7.2.0",
+            "@babel/plugin-transform-for-of": "^7.4.4",
+            "@babel/plugin-transform-function-name": "^7.4.4",
+            "@babel/plugin-transform-literals": "^7.2.0",
+            "@babel/plugin-transform-member-expression-literals": "^7.2.0",
+            "@babel/plugin-transform-modules-amd": "^7.5.0",
+            "@babel/plugin-transform-modules-commonjs": "^7.6.0",
+            "@babel/plugin-transform-modules-systemjs": "^7.5.0",
+            "@babel/plugin-transform-modules-umd": "^7.2.0",
+            "@babel/plugin-transform-named-capturing-groups-regex": "^7.6.3",
+            "@babel/plugin-transform-new-target": "^7.4.4",
+            "@babel/plugin-transform-object-super": "^7.5.5",
+            "@babel/plugin-transform-parameters": "^7.4.4",
+            "@babel/plugin-transform-property-literals": "^7.2.0",
+            "@babel/plugin-transform-regenerator": "^7.4.5",
+            "@babel/plugin-transform-reserved-words": "^7.2.0",
+            "@babel/plugin-transform-shorthand-properties": "^7.2.0",
+            "@babel/plugin-transform-spread": "^7.6.2",
+            "@babel/plugin-transform-sticky-regex": "^7.2.0",
+            "@babel/plugin-transform-template-literals": "^7.4.4",
+            "@babel/plugin-transform-typeof-symbol": "^7.2.0",
+            "@babel/plugin-transform-unicode-regex": "^7.6.2",
+            "@babel/types": "^7.6.3",
+            "browserslist": "^4.6.0",
+            "core-js-compat": "^3.1.1",
+            "invariant": "^2.2.2",
+            "js-levenshtein": "^1.1.3",
+            "semver": "^5.5.0"
+          },
+          "dependencies": {
+            "browserslist": {
+              "version": "4.7.2",
+              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.2.tgz",
+              "integrity": "sha512-uZavT/gZXJd2UTi9Ov7/Z340WOSQ3+m1iBVRUknf+okKxonL9P83S3ctiBDtuRmRu8PiCHjqyueqQ9HYlJhxiw==",
+              "dev": true,
+              "requires": {
+                "caniuse-lite": "^1.0.30001004",
+                "electron-to-chromium": "^1.3.295",
+                "node-releases": "^1.1.38"
+              }
+            }
+          }
+        },
+        "@babel/runtime": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
+          "integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "@babel/template": {
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
+          "integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/parser": "^7.6.0",
+            "@babel/types": "^7.6.0"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.3.tgz",
+          "integrity": "sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.5.5",
+            "@babel/generator": "^7.6.3",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.4.4",
+            "@babel/parser": "^7.6.3",
+            "@babel/types": "^7.6.3",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+          },
+          "dependencies": {
+            "@babel/code-frame": {
+              "version": "7.5.5",
+              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+              "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+              "dev": true,
+              "requires": {
+                "@babel/highlight": "^7.0.0"
+              }
+            }
+          }
+        },
+        "@babel/types": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
+          "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "@parcel/logger": {
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-1.11.1.tgz",
+          "integrity": "sha512-9NF3M6UVeP2udOBDILuoEHd8VrF4vQqoWHEafymO1pfSoOMfxrSJZw1MfyAAIUN/IFp9qjcpDCUbDZB+ioVevA==",
+          "dev": true,
+          "requires": {
+            "@parcel/workers": "^1.11.0",
+            "chalk": "^2.1.0",
+            "grapheme-breaker": "^0.3.2",
+            "ora": "^2.1.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "@parcel/watcher": {
+          "version": "1.12.1",
+          "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-1.12.1.tgz",
+          "integrity": "sha512-od+uCtCxC/KoNQAIE1vWx1YTyKYY+7CTrxBJPRh3cDWw/C0tCtlBMVlrbplscGoEpt6B27KhJDCv82PBxOERNA==",
+          "dev": true,
+          "requires": {
+            "@parcel/utils": "^1.11.0",
+            "chokidar": "^2.1.5"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001008",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001008.tgz",
+          "integrity": "sha512-b8DJyb+VVXZGRgJUa30cbk8gKHZ3LOZTBLaUEEVr2P4xpmFigOCc62CO4uzquW641Ouq1Rm9N+rWLWdSYDaDIw==",
+          "dev": true
+        },
+        "dotenv-expand": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
+          "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
+          "dev": true
+        },
+        "electron-to-chromium": {
+          "version": "1.3.302",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.302.tgz",
+          "integrity": "sha512-1qConyiVEbj4xZRBXqtGR003+9tV0rJF0PS6aeO0Ln/UL637js9hdwweCl07meh/kJoI2N4W8q3R3g3F5z46ww==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
+        "node-releases": {
+          "version": "1.1.39",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.39.tgz",
+          "integrity": "sha512-8MRC/ErwNCHOlAFycy9OPca46fQYUjbJRDcZTHVWIGXIjYLM73k70vv3WkYutVnM4cCo4hE0MqBVVZjP6vjISA==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.3.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+              "dev": true
+            }
+          }
+        },
+        "regenerate-unicode-properties": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
+          "integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
+          "dev": true,
+          "requires": {
+            "regenerate": "^1.4.0"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+          "dev": true
+        },
+        "regenerator-transform": {
+          "version": "0.14.1",
+          "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
+          "integrity": "sha512-flVuee02C3FKRISbxhXl9mGzdbWUVHubl1SMaknjxkFB1/iqpJhArQUvRxOOPEc/9tAiX0BaQ28FJH10E4isSQ==",
+          "dev": true,
+          "requires": {
+            "private": "^0.1.6"
+          }
+        },
+        "regexpu-core": {
+          "version": "4.6.0",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
+          "integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
+          "dev": true,
+          "requires": {
+            "regenerate": "^1.4.0",
+            "regenerate-unicode-properties": "^8.1.0",
+            "regjsgen": "^0.5.0",
+            "regjsparser": "^0.6.0",
+            "unicode-match-property-ecmascript": "^1.0.4",
+            "unicode-match-property-value-ecmascript": "^1.1.0"
+          }
+        },
+        "serialize-to-js": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-3.0.0.tgz",
+          "integrity": "sha512-WdGgi0jGnWCQXph2p3vkxceDnTfvfyXfYxherQMRcZjSaJzMQdMBAW6i0nojsBKIZ3fFOztZKKVbbm05VbIdRA==",
+          "dev": true
+        }
+      }
+    },
+    "parcel-bundler": {
+      "version": "npm:parcel@1.12.4",
+      "resolved": "https://registry.npmjs.org/parcel/-/parcel-1.12.4.tgz",
+      "integrity": "sha512-qfc74e2/R4pCoU6L/ZZnK9k3iDS6ir4uHea0e9th9w52eehcAGf2ido/iABq9PBXdsIOe4NSY3oUm7Khe7+S3w==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/core": "^7.4.4",
+        "@babel/generator": "^7.4.4",
+        "@babel/parser": "^7.4.4",
+        "@babel/plugin-transform-flow-strip-types": "^7.4.4",
+        "@babel/plugin-transform-modules-commonjs": "^7.4.4",
+        "@babel/plugin-transform-react-jsx": "^7.0.0",
+        "@babel/preset-env": "^7.4.4",
+        "@babel/runtime": "^7.4.4",
+        "@babel/template": "^7.4.4",
+        "@babel/traverse": "^7.4.4",
+        "@babel/types": "^7.4.4",
+        "@iarna/toml": "^2.2.0",
+        "@parcel/fs": "^1.11.0",
+        "@parcel/logger": "^1.11.1",
+        "@parcel/utils": "^1.11.0",
+        "@parcel/watcher": "^1.12.1",
+        "@parcel/workers": "^1.11.0",
+        "ansi-to-html": "^0.6.4",
+        "babylon-walk": "^1.0.2",
+        "browserslist": "^4.1.0",
+        "chalk": "^2.1.0",
+        "clone": "^2.1.1",
+        "command-exists": "^1.2.6",
+        "commander": "^2.11.0",
+        "core-js": "^2.6.5",
+        "cross-spawn": "^6.0.4",
+        "css-modules-loader-core": "^1.1.0",
+        "cssnano": "^4.0.0",
+        "deasync": "^0.1.14",
+        "dotenv": "^5.0.0",
+        "dotenv-expand": "^5.1.0",
+        "envinfo": "^7.3.1",
+        "fast-glob": "^2.2.2",
+        "filesize": "^3.6.0",
+        "get-port": "^3.2.0",
+        "htmlnano": "^0.2.2",
+        "is-glob": "^4.0.0",
+        "is-url": "^1.2.2",
+        "js-yaml": "^3.10.0",
+        "json5": "^1.0.1",
+        "micromatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "node-forge": "^0.7.1",
+        "node-libs-browser": "^2.0.0",
+        "opn": "^5.1.0",
+        "postcss": "^7.0.11",
+        "postcss-value-parser": "^3.3.1",
+        "posthtml": "^0.11.2",
+        "posthtml-parser": "^0.4.0",
+        "posthtml-render": "^1.1.3",
+        "resolve": "^1.4.0",
+        "semver": "^5.4.1",
+        "serialize-to-js": "^3.0.0",
+        "serve-static": "^1.12.4",
+        "source-map": "0.6.1",
+        "terser": "^3.7.3",
+        "v8-compile-cache": "^2.0.0",
+        "ws": "^5.1.1"
+      },
+      "dependencies": {
+        "@babel/generator": {
+          "version": "7.6.4",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
+          "integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.6.3",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "dev": true
+            }
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+          "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.4.4"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.6.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
+          "integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
+          "integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/parser": "^7.6.0",
+            "@babel/types": "^7.6.0"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.3.tgz",
+          "integrity": "sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.5.5",
+            "@babel/generator": "^7.6.3",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.4.4",
+            "@babel/parser": "^7.6.3",
+            "@babel/types": "^7.6.3",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+          },
+          "dependencies": {
+            "@babel/code-frame": {
+              "version": "7.5.5",
+              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+              "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+              "dev": true,
+              "requires": {
+                "@babel/highlight": "^7.0.0"
+              }
+            }
+          }
+        },
+        "@babel/types": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
+          "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "parse-asn1": {
@@ -5818,18 +7043,6 @@
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "dev": true
     },
-    "proto-list": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
-      "dev": true
-    },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
-    },
     "psl": {
       "version": "1.1.31",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
@@ -5949,24 +7162,24 @@
       "dev": true
     },
     "regenerate-unicode-properties": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.0.2.tgz",
-      "integrity": "sha512-SbA/iNrBUf6Pv2zU8Ekv1Qbhv92yxL4hiDa2siuxs4KKn4oOoMDHXjAf7+Nz9qinUQ46B1LcWEi/PhJfPWpZWQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
+      "integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
       "dev": true,
       "requires": {
         "regenerate": "^1.4.0"
       }
     },
     "regenerator-runtime": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
       "dev": true
     },
     "regenerator-transform": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.4.tgz",
-      "integrity": "sha512-T0QMBjK3J0MtxjPmdIMXm72Wvj2Abb0Bd4HADdfijwMdoIsyQZ6fWC7kDFhk2YinBBEMZDL7Y7wh0J1sGx3S4A==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
+      "integrity": "sha512-flVuee02C3FKRISbxhXl9mGzdbWUVHubl1SMaknjxkFB1/iqpJhArQUvRxOOPEc/9tAiX0BaQ28FJH10E4isSQ==",
       "dev": true,
       "requires": {
         "private": "^0.1.6"
@@ -5982,20 +7195,14 @@
         "safe-regex": "^1.1.0"
       }
     },
-    "regexp-tree": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.5.tgz",
-      "integrity": "sha512-nUmxvfJyAODw+0B13hj8CFVAxhe7fDEAgJgaotBu3nnR+IgGgZq59YedJP5VYTlkEfqjuK6TuRpnymKdatLZfQ==",
-      "dev": true
-    },
     "regexpu-core": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
-      "integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
+      "integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
       "dev": true,
       "requires": {
         "regenerate": "^1.4.0",
-        "regenerate-unicode-properties": "^8.0.2",
+        "regenerate-unicode-properties": "^8.1.0",
         "regjsgen": "^0.5.0",
         "regjsparser": "^0.6.0",
         "unicode-match-property-ecmascript": "^1.0.4",
@@ -6198,15 +7405,6 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
-    "safer-eval": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/safer-eval/-/safer-eval-1.3.2.tgz",
-      "integrity": "sha512-mAkc9NX+ULPw4qX+lkFVuIhXQbjFaX97fWFj6atFXMG11lUX4rXfQY6Q0VFf1wfJfqCHYO7cxtC7cA8fIkWsLQ==",
-      "dev": true,
-      "requires": {
-        "clones": "^1.2.0"
-      }
-    },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -6258,14 +7456,10 @@
       }
     },
     "serialize-to-js": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-1.2.2.tgz",
-      "integrity": "sha512-mUc8vA5iJghe+O+3s0YDGFLMJcqitVFk787YKiv8a4sf6RX5W0u81b+gcHrp15O0fFa010dRBVZvwcKXOWsL9Q==",
-      "dev": true,
-      "requires": {
-        "js-beautify": "^1.8.9",
-        "safer-eval": "^1.3.0"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-3.0.0.tgz",
+      "integrity": "sha512-WdGgi0jGnWCQXph2p3vkxceDnTfvfyXfYxherQMRcZjSaJzMQdMBAW6i0nojsBKIZ3fFOztZKKVbbm05VbIdRA==",
+      "dev": true
     },
     "serve-static": {
       "version": "1.13.2",
@@ -6343,12 +7537,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
-    },
-    "sigmund": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
       "dev": true
     },
     "signal-exit": {
@@ -7280,12 +8468,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
-    },
-    "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -31,11 +31,12 @@
   "author": "Jannick Garthen <jannick.garthen@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "parcel-bundler": "^1.12.3",
+    "parcel": "^1.12.4",
+    "parcel-bundler": "npm:parcel@^1.12.4",
     "postcss-modules": "^1.4.1",
     "prettier": "^1.16.4"
   },
   "peerDependencies": {
-    "parcel-bundler": "^1.11.0"
+    "parcel-bundler": "npm:parcel@^1.12.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,12 +31,11 @@
   "author": "Jannick Garthen <jannick.garthen@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "parcel": "^1.12.4",
-    "parcel-bundler": "npm:parcel@^1.12.4",
+    "parcel-bundler": "^1.12.4",
     "postcss-modules": "^1.4.1",
     "prettier": "^1.16.4"
   },
   "peerDependencies": {
-    "parcel-bundler": "npm:parcel@^1.12.4"
+    "parcel-bundler": "^1.11.0"
   }
 }

--- a/src/CssModulesTypedAsset.js
+++ b/src/CssModulesTypedAsset.js
@@ -2,13 +2,7 @@ const fs = require('fs');
 const os = require('os');
 const util = require('util');
 const helpers = require('./helpers');
-
-let CSSAsset = undefined;
-if (helpers.moduleExists('parcel-bundler')) {
-  CSSAsset = require('parcel-bundler/src/assets/CSSAsset');
-} else {
-  CSSAsset = require('parcel/src/assets/CSSAsset');
-}
+const CSSAsset = helpers.requireBundler('src/assets/CSSAsset');
 
 const writeFile = util.promisify(fs.writeFile);
 

--- a/src/CssModulesTypedAsset.js
+++ b/src/CssModulesTypedAsset.js
@@ -1,8 +1,15 @@
 const fs = require('fs');
 const os = require('os');
 const util = require('util');
+const helpers = require('./helpers');
 
-const CSSAsset = require('parcel-bundler/src/assets/CSSAsset');
+let CSSAsset = undefined;
+if (helpers.moduleExists('parcel-bundler')) {
+  CSSAsset = require('parcel-bundler/src/assets/CSSAsset');
+} else {
+  CSSAsset = require('parcel/src/assets/CSSAsset');
+}
+
 const writeFile = util.promisify(fs.writeFile);
 
 const writeDTSFile = (filename, keys) => {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,7 @@
+module.exports.moduleExists = name => {
+  try {
+    return require.resolve(name);
+  } catch (e) {
+    return false;
+  }
+};

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,7 +1,19 @@
-module.exports.moduleExists = name => {
+const path = require('path');
+
+const moduleExists = name => {
   try {
     return require.resolve(name);
   } catch (e) {
     return false;
   }
 };
+
+module.exports.requireBundler = (file = '') => {
+  if (moduleExists('parcel-bundler')) {
+    return require(path.join('parcel-bundler', file));
+  } else if (moduleExists('parcel')) {
+    return require(path.join('parcel', file));
+  }
+  return false;
+};
+

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,16 +1,11 @@
 const helpers = require('../src/helpers');
-let Bundler = undefined;
-if (helpers.moduleExists('parcel-bundler')) {
-  Bundler = require('parcel-bundler');
-} else {
-  Bundler = require('parcel');
-}
-
 const path = require('path');
 const fs = require('fs');
 const assert = require('assert');
 
 const plugin = require('../src/index');
+
+const Bundler = helpers.requireBundler();
 
 const bundle = async entry => {
   const bundler = new Bundler(path.join(__dirname, entry), {
@@ -23,6 +18,9 @@ const bundle = async entry => {
 };
 
 (async () => {
+  // make sure one of the required packages was loaded
+  assert (Bundler);
+
   // should create d.ts file
   await bundle('./css-modules.fixtures/index.js');
 
@@ -71,5 +69,5 @@ export = styles;`),
 export = styles;`),
   );
 
-  console.log('3/3 test passed');
+  console.log('4/4 tests passed');
 })();

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,4 +1,11 @@
-const Bundler = require('parcel-bundler');
+const helpers = require('../src/helpers');
+let Bundler = undefined;
+if (helpers.moduleExists('parcel-bundler')) {
+  Bundler = require('parcel-bundler');
+} else {
+  Bundler = require('parcel');
+}
+
 const path = require('path');
 const fs = require('fs');
 const assert = require('assert');


### PR DESCRIPTION
`parcel-bundler` is not the official package name anymore. Currently this means it will not work with projects, that just use `parcel` package. See also: https://github.com/parcel-bundler/parcel/issues/2937